### PR TITLE
Extend component to output additional CKEditor events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # CKEditor 4 Angular Integration Changelog
 
+## ckeditor4-angular 1.2.0
+
+New Features:
+
+* [#7](https://github.com/ckeditor/ckeditor4-angular/issues/7): CKEditor 4 component now exposes more CKEditor 4 native events. Thanks to [Eduard Zintz](https://github.com/ezintz)! New exposed events are:
+	* [paste](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#event-paste)
+	* [afterPaste](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#event-afterPaste)
+	* [dragStat](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#event-dragstart)
+	* [dragEnd](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#event-dragend)
+	* [drop](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#event-drop)
+	* [fileUploadRequest](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#event-fileUploadRequest)
+	* [fileUploadResponse](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#event-fileUploadResponse)
+
 ## ckeditor4-angular 1.1.0
 
 Other Changes:

--- a/src/app/simple-usage/simple-usage.component.html
+++ b/src/app/simple-usage/simple-usage.component.html
@@ -14,8 +14,14 @@
 		(ready)="onReady( $event, editor )"
 		(change)="onChange( $event, editor )"
 		(focus)="onFocus( $event, editor )"
-		(blur)="onBlur( $event, editor )">
-	</ckeditor>
+		(blur)="onBlur( $event, editor )"
+		(paste)="onPaste( $event, editor )"
+		(dragStart)="onDragStart( $event, editor )"
+		(dragEnd)="onDragEnd( $event, editor )"
+		(drop)="onDrop( $event, editor )"
+		(fileUploadRequest)="onFileUploadRequest( $event, editor )"
+		(fileUploadResponse)="onFileUploadResponse( $event, editor )"
+	></ckeditor>
 </div>
 
 <p>Note: editors have it's data synchronized, so every change in one of editors propagates to another.</p>

--- a/src/app/simple-usage/simple-usage.component.html
+++ b/src/app/simple-usage/simple-usage.component.html
@@ -16,6 +16,7 @@
 		(focus)="onFocus( $event, editor )"
 		(blur)="onBlur( $event, editor )"
 		(paste)="onPaste( $event, editor )"
+		(afterPaste)="onAfterPaste( $event, editor )"
 		(dragStart)="onDragStart( $event, editor )"
 		(dragEnd)="onDragEnd( $event, editor )"
 		(drop)="onDrop( $event, editor )"

--- a/src/app/simple-usage/simple-usage.component.ts
+++ b/src/app/simple-usage/simple-usage.component.ts
@@ -46,4 +46,28 @@ You learn to appreciate each and every single one of the differences while you b
 	onBlur( event: CKEditor4.EventInfo, editorName: string ): void {
 		console.log( `Blurred ${editorName.toLowerCase()} editing view.` );
 	}
+
+	onPaste( event: CKEditor4.EventInfo, editorName: string): void {
+		console.log( `Pasted ${editorName.toLowerCase()} editing view.` );
+	}
+
+	onDragStart( event: CKEditor4.EventInfo, editorName: string): void {
+		console.log( `Drag started ${editorName.toLowerCase()} editing view.` );
+	}
+
+	onDragEnd( event: CKEditor4.EventInfo, editorName: string): void {
+		console.log( `Drag ended ${editorName.toLowerCase()} editing view.` );
+	}
+
+	onDrop( event: CKEditor4.EventInfo, editorName: string): void {
+		console.log( `Dropped ${editorName.toLowerCase()} editing view.` );
+	}
+
+	onFileUploadRequest( event: CKEditor4.EventInfo, editorName: string): void {
+		console.log( `File upload requested ${editorName.toLowerCase()} editing view.` );
+	}
+
+	onFileUploadResponse( event: CKEditor4.EventInfo, editorName: string): void {
+		console.log( `File upload responded ${editorName.toLowerCase()} editing view.` );
+	}
 }

--- a/src/app/simple-usage/simple-usage.component.ts
+++ b/src/app/simple-usage/simple-usage.component.ts
@@ -48,30 +48,30 @@ You learn to appreciate each and every single one of the differences while you b
 	}
 
 	onPaste( event: CKEditor4.EventInfo, editorName: string ): void {
-		console.log( `Pasted ${editorName.toLowerCase()} editing view.` );
+		console.log( `Pasted into ${editorName.toLowerCase()} editing view.` );
 	}
 
 	onAfterPaste( event: CKEditor4.EventInfo, editorName: string ): void {
-		console.log( `After paste  ${editorName.toLowerCase()} editing view.` );
+		console.log( `After pasted fired in ${editorName.toLowerCase()} editing view.` );
 	}
 
 	onDragStart( event: CKEditor4.EventInfo, editorName: string ): void {
-		console.log( `Drag started ${editorName.toLowerCase()} editing view.` );
+		console.log( `Drag started in ${editorName.toLowerCase()} editing view.` );
 	}
 
 	onDragEnd( event: CKEditor4.EventInfo, editorName: string ): void {
-		console.log( `Drag ended ${editorName.toLowerCase()} editing view.` );
+		console.log( `Drag ended in ${editorName.toLowerCase()} editing view.` );
 	}
 
 	onDrop( event: CKEditor4.EventInfo, editorName: string ): void {
-		console.log( `Dropped ${editorName.toLowerCase()} editing view.` );
+		console.log( `Dropped in ${editorName.toLowerCase()} editing view.` );
 	}
 
 	onFileUploadRequest( event: CKEditor4.EventInfo, editorName: string ): void {
-		console.log( `File upload requested ${editorName.toLowerCase()} editing view.` );
+		console.log( `File upload requested in ${editorName.toLowerCase()} editor.` );
 	}
 
 	onFileUploadResponse( event: CKEditor4.EventInfo, editorName: string ): void {
-		console.log( `File upload responded ${editorName.toLowerCase()} editing view.` );
+		console.log( `File upload responded in ${editorName.toLowerCase()} editor.` );
 	}
 }

--- a/src/app/simple-usage/simple-usage.component.ts
+++ b/src/app/simple-usage/simple-usage.component.ts
@@ -47,27 +47,31 @@ You learn to appreciate each and every single one of the differences while you b
 		console.log( `Blurred ${editorName.toLowerCase()} editing view.` );
 	}
 
-	onPaste( event: CKEditor4.EventInfo, editorName: string): void {
+	onPaste( event: CKEditor4.EventInfo, editorName: string ): void {
 		console.log( `Pasted ${editorName.toLowerCase()} editing view.` );
 	}
 
-	onDragStart( event: CKEditor4.EventInfo, editorName: string): void {
+	onAfterPaste( event: CKEditor4.EventInfo, editorName: string ): void {
+		console.log( `After paste  ${editorName.toLowerCase()} editing view.` );
+	}
+
+	onDragStart( event: CKEditor4.EventInfo, editorName: string ): void {
 		console.log( `Drag started ${editorName.toLowerCase()} editing view.` );
 	}
 
-	onDragEnd( event: CKEditor4.EventInfo, editorName: string): void {
+	onDragEnd( event: CKEditor4.EventInfo, editorName: string ): void {
 		console.log( `Drag ended ${editorName.toLowerCase()} editing view.` );
 	}
 
-	onDrop( event: CKEditor4.EventInfo, editorName: string): void {
+	onDrop( event: CKEditor4.EventInfo, editorName: string ): void {
 		console.log( `Dropped ${editorName.toLowerCase()} editing view.` );
 	}
 
-	onFileUploadRequest( event: CKEditor4.EventInfo, editorName: string): void {
+	onFileUploadRequest( event: CKEditor4.EventInfo, editorName: string ): void {
 		console.log( `File upload requested ${editorName.toLowerCase()} editing view.` );
 	}
 
-	onFileUploadResponse( event: CKEditor4.EventInfo, editorName: string): void {
+	onFileUploadResponse( event: CKEditor4.EventInfo, editorName: string ): void {
 		console.log( `File upload responded ${editorName.toLowerCase()} editing view.` );
 	}
 }

--- a/src/ckeditor/ckeditor.component.spec.ts
+++ b/src/ckeditor/ckeditor.component.spec.ts
@@ -410,6 +410,49 @@ describe( 'CKEditorComponent', () => {
 
 						done();
 					} );
+
+					it( 'fileUploadRequest should emit component fileUploadRequest', () => {
+						fixture.detectChanges();
+
+						const spy = jasmine.createSpy();
+						component.fileUploadRequest.subscribe( spy );
+
+						const fileLoaderMock = {
+							fileLoader: {
+								file: Blob ? new Blob() : '',
+								fileName: 'fileName',
+								xhr: {
+									open: function() {},
+									send: function() {}
+								}
+							},
+							requestData: {}
+						};
+
+						component.instance.fire( 'fileUploadRequest', fileLoaderMock );
+
+						expect( spy ).toHaveBeenCalledTimes( 1 );
+					} );
+
+					it( 'fileUploadResponse should emit component fileUploadResponse', () => {
+						fixture.detectChanges();
+
+						const spy = jasmine.createSpy();
+						component.fileUploadResponse.subscribe( spy );
+
+						const data = {
+							fileLoader: {
+								xhr: { responseText: 'Not a JSON.' },
+								lang: {
+									filetools: { responseError: 'Error' }
+								}
+							}
+						};
+
+						component.instance.fire( 'fileUploadResponse', data );
+
+						expect( spy ).toHaveBeenCalledTimes( 1 );
+					} );
 				} );
 
 				describe( 'when control value accessor callbacks are set', () => {

--- a/src/ckeditor/ckeditor.component.spec.ts
+++ b/src/ckeditor/ckeditor.component.spec.ts
@@ -9,6 +9,8 @@ import { whenEvent, whenDataReady, setDataMultipleTimes } from '../test.tools';
 import { CKEditor4 } from './ckeditor';
 import EditorType = CKEditor4.EditorType;
 
+const { mockNativeDataTransfer, mockPasteEvent, whenEvent } = TestTools;
+
 declare var CKEDITOR: any;
 
 describe( 'CKEditorComponent', () => {
@@ -348,11 +350,14 @@ describe( 'CKEditorComponent', () => {
 
 					it( 'paste should emit component paste', () => {
 						fixture.detectChanges();
+						const event = mockPasteEvent();
+						event.$.clipboardData.setData( 'text/html', '<p>bam</p>' );
 
 						const spy = jasmine.createSpy();
 						component.paste.subscribe( spy );
 
-						component.instance.fire( 'paste' );
+						// const editable = component.instance.editable();
+						component.instance.fire( 'paste', event );
 
 						expect( spy ).toHaveBeenCalledTimes( 1 );
 					} );

--- a/src/ckeditor/ckeditor.component.spec.ts
+++ b/src/ckeditor/ckeditor.component.spec.ts
@@ -7,8 +7,11 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { CKEditorComponent } from './ckeditor.component';
 import {
 	fireDragEndEvent,
-	fireDragStartEvent, fireDropEvent, getWidgetById,
-	mockDropEvent, mockNativeDataTransfer,
+	fireDragStartEvent,
+	fireDropEvent,
+	getWidgetById,
+	mockDropEvent,
+	mockNativeDataTransfer,
 	mockPasteEvent,
 	setDataMultipleTimes,
 	whenDataPasted,

--- a/src/ckeditor/ckeditor.component.spec.ts
+++ b/src/ckeditor/ckeditor.component.spec.ts
@@ -373,6 +373,24 @@ describe( 'CKEditorComponent', () => {
 						} );
 					} );
 
+					it( 'afterPaste should emit component afterPaste', () => {
+						const pasteEventMock = mockPasteEvent();
+						pasteEventMock.$.clipboardData.setData( 'text/html', '<p>bam</p>' );
+
+						fixture.detectChanges();
+
+						const spy = jasmine.createSpy();
+						component.afterPaste.subscribe( spy );
+
+						const editable = component.instance.editable();
+						editable.fire( 'paste', pasteEventMock );
+
+						return whenEvent( 'afterPaste', component ).then( () => {
+							expect( spy ).toHaveBeenCalledTimes( 1 );
+							expect( component.instance.getData() ).toEqual( '<p>bam</p>\n' );
+						} );
+					} );
+
 					it( 'drag and drop events should emit component dragstart, drop and dragEnd', async done => {
 						fixture.detectChanges();
 

--- a/src/ckeditor/ckeditor.component.spec.ts
+++ b/src/ckeditor/ckeditor.component.spec.ts
@@ -345,6 +345,78 @@ describe( 'CKEditorComponent', () => {
 
 						expect( spy ).toHaveBeenCalledTimes( 1 );
 					} );
+
+					it( 'paste should emit component paste', () => {
+						fixture.detectChanges();
+
+						const spy = jasmine.createSpy();
+						component.paste.subscribe( spy );
+
+						component.instance.fire( 'paste' );
+
+						expect( spy ).toHaveBeenCalledTimes( 1 );
+					} );
+
+					it( 'dragend should emit component dragend', () => {
+						fixture.detectChanges();
+
+						const spy = jasmine.createSpy();
+						component.dragEnd.subscribe( spy );
+
+						component.instance.fire( 'dragend' );
+
+						expect( spy ).toHaveBeenCalledTimes( 1 );
+					});
+
+					it( 'dragstart should emit component dragstart', () => {
+						fixture.detectChanges();
+
+						const spy = jasmine.createSpy();
+						component.dragStart.subscribe( spy );
+
+						component.instance.fire( 'dragstart' );
+
+						expect( spy ).toHaveBeenCalledTimes( 1 );
+					} );
+
+					it( 'drop should emit component drop', () => {
+						fixture.detectChanges();
+
+						const spy = jasmine.createSpy();
+						component.drop.subscribe( spy );
+
+						component.instance.fire( 'drop' );
+
+						expect( spy ).toHaveBeenCalledTimes( 1 );
+					} );
+
+					it('fileUploadRequest should emit component fileUploadRequest', () => {
+						component.config = {
+							extraPlugins: 'uploadimage'
+						};
+						fixture.detectChanges();
+
+						const spy = jasmine.createSpy();
+						component.fileUploadRequest.subscribe( spy );
+
+						component.instance.fire( 'fileUploadRequest' );
+
+						expect( spy ).toHaveBeenCalledTimes( 1 );
+					} );
+
+					it('fileUploadResponse should emit component fileUploadResponse', () => {
+						component.config = {
+							extraPlugins: 'uploadimage'
+						};
+						fixture.detectChanges();
+
+						const spy = jasmine.createSpy();
+						component.fileUploadResponse.subscribe( spy );
+
+						component.instance.fire( 'fileUploadResponse' );
+
+						expect( spy ).toHaveBeenCalledTimes( 1 );
+					} );
 				} );
 
 				describe( 'when control value accessor callbacks are set', () => {

--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -115,11 +115,11 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 	}
 
 	/**
-	 * Fires when the editing view of the editor is blurred. It corresponds with the `editor#blur`
-	 * https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#event-blur
+	 * Fires when the editor is ready. It corresponds with the `editor#instanceReady`
+	 * https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#event-instanceReady
 	 * event.
 	 */
-	@Output() blur = new EventEmitter<CKEditor4.EventInfo>();
+	@Output() ready = new EventEmitter<CKEditor4.EventInfo>();
 
 	/**
 	 * Fires when the editor data is loaded, e.g. after calling setData()
@@ -204,11 +204,11 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 	@Output() afterPaste = new EventEmitter<CKEditor4.EventInfo>();
 
 	/**
-	 * Fires when the editor is ready. It corresponds with the `editor#instanceReady`
-	 * https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#event-instanceReady
+	 * Fires when the editing view of the editor is blurred. It corresponds with the `editor#blur`
+	 * https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#event-blur
 	 * event.
 	 */
-	@Output() ready = new EventEmitter<CKEditor4.EventInfo>();
+	@Output() blur = new EventEmitter<CKEditor4.EventInfo>();
 
 	/**
 	 * The instance of the editor created by this component.

--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -147,40 +147,35 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 	@Output() dataChange = new EventEmitter<CKEditor4.EventInfo>();
 
 	/**
-	 * Facade for the native drop event. Fired when the native drop event occurs.
-	 * It corresponds with the `editor#dragend`
-	 * https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#event-dragend
-	 * event.
-	 */
-	@Output() dragEnd = new EventEmitter<CKEditor4.EventInfo>();
-
-	/**
-	 * Facade for the native drop event. Fired when the native drop event occurs.
-	 * It corresponds with the `editor#dragstart`
+	 * Fires when the native drop event occurs. It corresponds with the `editor#dragstart`
 	 * https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#event-dragstart
 	 * event.
 	 */
 	@Output() dragStart = new EventEmitter<CKEditor4.EventInfo>();
 
 	/**
-	 * Facade for the native drop event. Fired when the native drop event occurs.
-	 * It corresponds with the `editor#drop`
+	 * Fires when the native drop event occurs. It corresponds with the `editor#dragend`
+	 * https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#event-dragend
+	 * event.
+	 */
+	@Output() dragEnd = new EventEmitter<CKEditor4.EventInfo>();
+
+	/**
+	 * Fires when the native drop event occurs. It corresponds with the `editor#drop`
 	 * https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#event-drop
 	 * event.
 	 */
 	@Output() drop = new EventEmitter<CKEditor4.EventInfo>();
 
 	/**
-	 * Fires when the file loader response is received. It corresponds with the
-	 * `editor#fileUploadResponse`
+	 * Fires when the file loader response is received. It corresponds with the `editor#fileUploadResponse`
 	 * https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#event-fileUploadResponse
 	 * event.
 	 */
 	@Output() fileUploadResponse = new EventEmitter<CKEditor4.EventInfo>();
 
 	/**
-	 * Fires when the file loader should send XHR. It corresponds with the
-	 * `editor#fileUploadRequest`
+	 * Fires when the file loader should send XHR. It corresponds with the `editor#fileUploadRequest`
 	 * https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#event-fileUploadRequest
 	 * event.
 	 */
@@ -410,10 +405,7 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 		let { extraPlugins, removePlugins } = config;
 
 		extraPlugins = this.removePlugin( extraPlugins, 'divarea' ) || '';
-		extraPlugins = extraPlugins.concat( typeof extraPlugins === 'string'
-			? ',divarea'
-			: 'divarea'
-		);
+		extraPlugins = extraPlugins.concat( typeof extraPlugins === 'string' ? ',divarea' : 'divarea' );
 
 		if ( removePlugins && removePlugins.includes( 'divarea' ) ) {
 

--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -197,6 +197,13 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 	@Output() paste = new EventEmitter<CKEditor4.EventInfo>();
 
 	/**
+	 * Fires after the `paste` event if content was modified. It corresponds with the `editor#afterPaste`
+	 * https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#event-afterPaste
+	 * event.
+	 */
+	@Output() afterPaste = new EventEmitter<CKEditor4.EventInfo>();
+
+	/**
 	 * Fires when the editor is ready. It corresponds with the `editor#instanceReady`
 	 * https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#event-instanceReady
 	 * event.
@@ -324,6 +331,12 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 		editor.on( 'paste', evt => {
 			this.ngZone.run( () => {
 				this.paste.emit( evt );
+			} );
+		} );
+
+		editor.on( 'afterPaste', evt => {
+			this.ngZone.run( () => {
+				this.afterPaste.emit( evt );
 			} );
 		} );
 

--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -115,11 +115,11 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 	}
 
 	/**
-	 * Fires when the editor is ready. It corresponds with the `editor#instanceReady`
-	 * https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#event-instanceReady
+	 * Fires when the editing view of the editor is blurred. It corresponds with the `editor#blur`
+	 * https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#event-blur
 	 * event.
 	 */
-	@Output() ready = new EventEmitter<CKEditor4.EventInfo>();
+	@Output() blur = new EventEmitter<CKEditor4.EventInfo>();
 
 	/**
 	 * Fires when the editor data is loaded, e.g. after calling setData()
@@ -147,6 +147,46 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 	@Output() dataChange = new EventEmitter<CKEditor4.EventInfo>();
 
 	/**
+	 * Facade for the native drop event. Fired when the native drop event occurs.
+	 * It corresponds with the `editor#dragend`
+	 * https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#event-dragend
+	 * event.
+	 */
+	@Output() dragEnd = new EventEmitter<CKEditor4.EventInfo>();
+
+	/**
+	 * Facade for the native drop event. Fired when the native drop event occurs.
+	 * It corresponds with the `editor#dragstart`
+	 * https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#event-dragstart
+	 * event.
+	 */
+	@Output() dragStart = new EventEmitter<CKEditor4.EventInfo>();
+
+	/**
+	 * Facade for the native drop event. Fired when the native drop event occurs.
+	 * It corresponds with the `editor#drop`
+	 * https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#event-drop
+	 * event.
+	 */
+	@Output() drop = new EventEmitter<CKEditor4.EventInfo>();
+
+	/**
+	 * Fires when the file loader response is received. It corresponds with the
+	 * `editor#fileUploadResponse`
+	 * https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#event-fileUploadResponse
+	 * event.
+	 */
+	@Output() fileUploadResponse = new EventEmitter<CKEditor4.EventInfo>();
+
+	/**
+	 * Fires when the file loader should send XHR. It corresponds with the
+	 * `editor#fileUploadRequest`
+	 * https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#event-fileUploadRequest
+	 * event.
+	 */
+	@Output() fileUploadRequest = new EventEmitter<CKEditor4.EventInfo>();
+
+	/**
 	 * Fires when the editing view of the editor is focused. It corresponds with the `editor#focus`
 	 * https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#event-focus
 	 * event.
@@ -154,11 +194,19 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 	@Output() focus = new EventEmitter<CKEditor4.EventInfo>();
 
 	/**
-	 * Fires when the editing view of the editor is blurred. It corresponds with the `editor#blur`
-	 * https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#event-blur
+	 * Fires after the user initiated a paste action, but before the data is inserted.
+	 * It corresponds with the `editor#paste`
+	 * https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#event-paste
 	 * event.
 	 */
-	@Output() blur = new EventEmitter<CKEditor4.EventInfo>();
+	@Output() paste = new EventEmitter<CKEditor4.EventInfo>();
+
+	/**
+	 * Fires when the editor is ready. It corresponds with the `editor#instanceReady`
+	 * https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#event-instanceReady
+	 * event.
+	 */
+	@Output() ready = new EventEmitter<CKEditor4.EventInfo>();
 
 	/**
 	 * The instance of the editor created by this component.
@@ -278,6 +326,42 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 			} );
 		} );
 
+		editor.on( 'paste', evt => {
+			this.ngZone.run( () => {
+				this.paste.emit( evt );
+			} );
+		} );
+
+		editor.on( 'dragend', evt => {
+			this.ngZone.run( () => {
+				this.dragEnd.emit( evt );
+			} );
+		});
+
+		editor.on( 'dragstart', evt => {
+			this.ngZone.run( () => {
+				this.dragStart.emit( evt );
+			} );
+		} );
+
+		editor.on( 'drop', evt => {
+			this.ngZone.run( () => {
+				this.drop.emit( evt );
+			} );
+		} );
+
+		editor.on( 'fileUploadRequest', evt => {
+			this.ngZone.run( () => {
+				this.fileUploadRequest.emit(evt);
+			} );
+		} );
+
+		editor.on( 'fileUploadResponse', evt => {
+			this.ngZone.run(() => {
+				this.fileUploadResponse.emit(evt);
+			} );
+		} );
+
 		editor.on( 'blur', evt => {
 			this.ngZone.run( () => {
 				if ( this.onTouched ) {
@@ -326,7 +410,10 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 		let { extraPlugins, removePlugins } = config;
 
 		extraPlugins = this.removePlugin( extraPlugins, 'divarea' ) || '';
-		extraPlugins = extraPlugins.concat( typeof extraPlugins === 'string' ? ',divarea' : 'divarea' );
+		extraPlugins = extraPlugins.concat( typeof extraPlugins === 'string'
+			? ',divarea'
+			: 'divarea'
+		);
 
 		if ( removePlugins && removePlugins.includes( 'divarea' ) ) {
 

--- a/src/test.tools.ts
+++ b/src/test.tools.ts
@@ -41,3 +41,96 @@ function setDataHelper( editor: any, data: Array<string>, done: Function ) {
 		setTimeout( done, 100 );
 	}
 }
+
+declare var CKEDITOR: any;
+
+export class TestTools {
+	static whenEvent( evtName: string, component: CKEditorComponent ) {
+		return new Promise( res => {
+			component[ evtName ].subscribe( res );
+		} );
+	}
+
+	static mockNativeDataTransfer() {
+		return {
+			types: [],
+			files: CKEDITOR.env.ie && CKEDITOR.env.version < 10 ? undefined : [],
+			_data: {},
+			// Emulate browsers native behavior for getData/setData.
+			setData: function( type, data ) {
+				if ( CKEDITOR.env.ie && CKEDITOR.env.version < 16 && type != 'Text' && type != 'URL' ) {
+					throw 'Unexpected call to method or property access.';
+				}
+
+				if ( CKEDITOR.env.ie && CKEDITOR.env.version > 9 && type == 'URL' ) {
+					return;
+				}
+
+				// While Edge 16+ supports Clipboard API, it does not support custom mime types
+				// in `setData` and throws `Element not found.` if such are used.
+				if ( CKEDITOR.env.edge && CKEDITOR.env.version >= 16 &&
+					CKEDITOR.tools.indexOf(
+						[ 'Text', 'URL', 'text/plain', 'text/html', 'application/xml' ],
+						type
+					) === -1) {
+
+					throw {
+						name: 'Error',
+						message: 'Element not found.'
+					};
+				}
+
+				if ( type == 'text/plain' || type == 'Text' ) {
+					this._data[ 'text/plain' ] = data;
+					this._data.Text = data;
+				} else {
+					this._data[ type ] = data;
+				}
+
+				this.types.push( type );
+			},
+			getData: function( type ) {
+				if ( CKEDITOR.env.ie && CKEDITOR.env.version < 16 && type != 'Text' && type != 'URL' ) {
+					throw 'Invalid argument.';
+				}
+
+				if ( typeof this._data[ type ] === 'undefined' || this._data[ type ] === null ) {
+					return '';
+				}
+
+				return this._data[ type ];
+			},
+			clearData: function( type ) {
+				var index = CKEDITOR.tools.indexOf( this.types, type );
+
+				if ( index !== -1 ) {
+					delete this._data[ type ];
+					this.types.splice( index, 1 );
+				}
+			}
+		};
+	}
+
+	static mockPasteEvent() {
+		const dataTransfer = TestTools.mockNativeDataTransfer()
+		let target = new CKEDITOR.dom.node('targetMock')
+
+		return {
+			$: {
+				ctrlKey: true,
+				clipboardData: ( CKEDITOR.env.ie && CKEDITOR.env.version < 16 )
+					? undefined
+					: dataTransfer
+			},
+			preventDefault: function() {
+				// noop
+			},
+			getTarget: function() {
+				return target;
+			},
+			setTarget: function( t: any ) {
+				target = t;
+			}
+		};
+	}
+}

--- a/src/test.tools.ts
+++ b/src/test.tools.ts
@@ -1,5 +1,7 @@
 import { CKEditorComponent } from './ckeditor/ckeditor.component';
 
+declare var CKEDITOR: any;
+
 export function whenEvent( evtName: string, component: CKEditorComponent ) {
 	return new Promise( res => {
 		component[ evtName ].subscribe( res );
@@ -16,6 +18,20 @@ export function whenDataReady( editor: any, callback?: Function ) {
 	} );
 }
 
+export function whenDataPasted( editor: any, skipCancel = false) {
+	return new Promise( res => {
+		editor.once( 'paste', evt => {
+			evt.removeListener();
+
+			if ( !skipCancel ) {
+				evt.cancel(); // Cancel for performance reason - we don't need insertion happen.
+			}
+
+			res();
+		}, null, null, 9999 );
+	} );
+}
+
 export function setDataMultipleTimes( editor: any, data: Array<string> ) {
 	return new Promise( res => {
 		if ( !editor.editable().isInline() ) {
@@ -27,6 +43,156 @@ export function setDataMultipleTimes( editor: any, data: Array<string> ) {
 			res();
 		}
 	} );
+}
+
+export function mockNativeDataTransfer() {
+	return {
+		types: [],
+		files: CKEDITOR.env.ie && CKEDITOR.env.version < 10 ? undefined : [],
+		_data: {},
+		// Emulate browsers native behavior for getData/setData.
+		setData: function( type, data ) {
+			if ( CKEDITOR.env.ie && CKEDITOR.env.version < 16 && type != 'Text' && type != 'URL' ) {
+				throw 'Unexpected call to method or property access.';
+			}
+
+			if ( CKEDITOR.env.ie && CKEDITOR.env.version > 9 && type == 'URL' ) {
+				return;
+			}
+
+			// While Edge 16+ supports Clipboard API, it does not support custom mime types
+			// in `setData` and throws `Element not found.` if such are used.
+			if ( CKEDITOR.env.edge && CKEDITOR.env.version >= 16 &&
+				CKEDITOR.tools.indexOf(
+					[ 'Text', 'URL', 'text/plain', 'text/html', 'application/xml' ],
+					type
+				) === -1) {
+
+				throw {
+					name: 'Error',
+					message: 'Element not found.'
+				};
+			}
+
+			if ( type == 'text/plain' || type == 'Text' ) {
+				this._data[ 'text/plain' ] = data;
+				this._data.Text = data;
+			} else {
+				this._data[ type ] = data;
+			}
+
+			this.types.push( type );
+		},
+		getData: function( type ) {
+			if ( CKEDITOR.env.ie && CKEDITOR.env.version < 16 && type != 'Text' && type != 'URL' ) {
+				throw 'Invalid argument.';
+			}
+
+			if ( typeof this._data[ type ] === 'undefined' || this._data[ type ] === null ) {
+				return '';
+			}
+
+			return this._data[ type ];
+		},
+		clearData: function( type ) {
+			var index = CKEDITOR.tools.indexOf( this.types, type );
+
+			if ( index !== -1 ) {
+				delete this._data[ type ];
+				this.types.splice( index, 1 );
+			}
+		}
+	};
+}
+
+export function mockPasteEvent() {
+	const dataTransfer = mockNativeDataTransfer()
+	let target = new CKEDITOR.dom.node('targetMock')
+
+	return {
+		$: {
+			ctrlKey: true,
+			clipboardData: ( CKEDITOR.env.ie && CKEDITOR.env.version < 16 )
+				? undefined
+				: dataTransfer
+		},
+		preventDefault: function() {
+			// noop
+		},
+		getTarget: function() {
+			return target;
+		},
+		setTarget: function( t: any ) {
+			target = t;
+		}
+	};
+}
+
+export function mockDropEvent() {
+	var dataTransfer = this.mockNativeDataTransfer();
+	var target = new CKEDITOR.dom.text( 'targetMock' );
+
+	target.isReadOnly = function() {
+		return false;
+	};
+
+	return {
+		$: {
+			dataTransfer: dataTransfer
+		},
+		preventDefault: function() {
+			// noop
+		},
+		getTarget: function() {
+			return target;
+		},
+		setTarget: function( t ) {
+			target = t;
+		}
+	};
+}
+
+export function fireDragStartEvent( editor: any, evt: any, widgetOrNode: any ) {
+	const dropTarget = CKEDITOR.plugins.clipboard.getDropTarget( editor );
+	const dragTarget = getDragEventTarget( widgetOrNode );
+
+	// Use realistic target which is the drag handler or the element.
+	evt.setTarget( dragTarget );
+
+	dropTarget.fire( 'dragstart', evt );
+}
+
+export function getWidgetById( editor: any, id: string, byElement = false ) {
+	var widget = editor.widgets.getByElement( editor.document.getById( id ) );
+
+	if ( widget && byElement ) {
+		return widget.element.$.id == id ? widget : null;
+	}
+
+	return widget;
+}
+
+export function fireDropEvent( editor: any, evt: any, dropRange: any ) {
+	const dropTarget = CKEDITOR.env.ie && CKEDITOR.env.version < 9 ? editor.editable() : editor.document;
+
+	// If drop range is known use a realistic target. If no, then use a mock.
+	if ( dropRange ) {
+		evt.setTarget( dropRange.startContainer );
+	} else {
+		evt.setTarget( new CKEDITOR.dom.text( 'targetMock' ) );
+	}
+
+	dropTarget.fire( 'drop', evt );
+}
+
+export function fireDragEndEvent( editor: any, evt: any, widgetOrNode: any ) {
+	const dropTarget = CKEDITOR.env.ie && CKEDITOR.env.version < 9 ? editor.editable() : editor.document;
+	const dragTarget = getDragEventTarget( widgetOrNode );
+
+	// Use realistic target which is the drag handler or the element.
+	evt.setTarget( dragTarget );
+
+	dropTarget.fire( 'dragend', evt );
 }
 
 function setDataHelper( editor: any, data: Array<string>, done: Function ) {
@@ -42,95 +208,10 @@ function setDataHelper( editor: any, data: Array<string>, done: Function ) {
 	}
 }
 
-declare var CKEDITOR: any;
-
-export class TestTools {
-	static whenEvent( evtName: string, component: CKEditorComponent ) {
-		return new Promise( res => {
-			component[ evtName ].subscribe( res );
-		} );
+function getDragEventTarget( widgetOrNode ) {
+	if ( !widgetOrNode.dragHandlerContainer ) {
+		return widgetOrNode;
 	}
 
-	static mockNativeDataTransfer() {
-		return {
-			types: [],
-			files: CKEDITOR.env.ie && CKEDITOR.env.version < 10 ? undefined : [],
-			_data: {},
-			// Emulate browsers native behavior for getData/setData.
-			setData: function( type, data ) {
-				if ( CKEDITOR.env.ie && CKEDITOR.env.version < 16 && type != 'Text' && type != 'URL' ) {
-					throw 'Unexpected call to method or property access.';
-				}
-
-				if ( CKEDITOR.env.ie && CKEDITOR.env.version > 9 && type == 'URL' ) {
-					return;
-				}
-
-				// While Edge 16+ supports Clipboard API, it does not support custom mime types
-				// in `setData` and throws `Element not found.` if such are used.
-				if ( CKEDITOR.env.edge && CKEDITOR.env.version >= 16 &&
-					CKEDITOR.tools.indexOf(
-						[ 'Text', 'URL', 'text/plain', 'text/html', 'application/xml' ],
-						type
-					) === -1) {
-
-					throw {
-						name: 'Error',
-						message: 'Element not found.'
-					};
-				}
-
-				if ( type == 'text/plain' || type == 'Text' ) {
-					this._data[ 'text/plain' ] = data;
-					this._data.Text = data;
-				} else {
-					this._data[ type ] = data;
-				}
-
-				this.types.push( type );
-			},
-			getData: function( type ) {
-				if ( CKEDITOR.env.ie && CKEDITOR.env.version < 16 && type != 'Text' && type != 'URL' ) {
-					throw 'Invalid argument.';
-				}
-
-				if ( typeof this._data[ type ] === 'undefined' || this._data[ type ] === null ) {
-					return '';
-				}
-
-				return this._data[ type ];
-			},
-			clearData: function( type ) {
-				var index = CKEDITOR.tools.indexOf( this.types, type );
-
-				if ( index !== -1 ) {
-					delete this._data[ type ];
-					this.types.splice( index, 1 );
-				}
-			}
-		};
-	}
-
-	static mockPasteEvent() {
-		const dataTransfer = TestTools.mockNativeDataTransfer()
-		let target = new CKEDITOR.dom.node('targetMock')
-
-		return {
-			$: {
-				ctrlKey: true,
-				clipboardData: ( CKEDITOR.env.ie && CKEDITOR.env.version < 16 )
-					? undefined
-					: dataTransfer
-			},
-			preventDefault: function() {
-				// noop
-			},
-			getTarget: function() {
-				return target;
-			},
-			setTarget: function( t: any ) {
-				target = t;
-			}
-		};
-	}
+	return widgetOrNode.dragHandlerContainer.findOne( 'img' );
 }

--- a/src/test.tools.ts
+++ b/src/test.tools.ts
@@ -33,7 +33,7 @@ export function setDataMultipleTimes( editor: any, data: Array<string> ) {
 
 export function mockPasteEvent() {
 	const dataTransfer = mockNativeDataTransfer();
-	let target = new CKEDITOR.dom.node( 'targetMock' );
+	let target = new CKEDITOR.dom.element( 'div' );
 
 	return {
 		$: {
@@ -51,8 +51,8 @@ export function mockPasteEvent() {
 }
 
 export function mockDropEvent() {
-	const dataTransfer = this.mockNativeDataTransfer();
-	let target = new CKEDITOR.dom.text( 'targetMock' );
+	const dataTransfer = mockNativeDataTransfer();
+	let target = new CKEDITOR.dom.element( 'div' );
 
 	target.isReadOnly = function() {
 		return false;
@@ -72,33 +72,10 @@ export function mockDropEvent() {
 	};
 }
 
-export function fireDragEvent( eventName: string, editor: any, evt: any, widgetOrNode: any ) {
+export function fireDragEvent( eventName: string, editor: any, evt: any ) {
 	const dropTarget = CKEDITOR.plugins.clipboard.getDropTarget( editor );
-	const dragTarget = getDragEventTarget( widgetOrNode );
-
-	// Use realistic target which is the drag handler or the element.
-	evt.setTarget( dragTarget );
 
 	dropTarget.fire( eventName, evt );
-}
-
-export function fireDropEvent( editor: any, evt: any, dropRange: any ) {
-	const dropTarget = CKEDITOR.plugins.clipboard.getDropTarget( editor );
-
-	// If drop range is known use a realistic target. If no, then use a mock.
-	evt.setTarget( dropRange ? dropRange.startContainer : new CKEDITOR.dom.text( 'targetMock' ) );
-
-	dropTarget.fire( 'drop', evt );
-}
-
-export function getWidgetById( editor: any, id: string, byElement = false ) {
-	const widget = editor.widgets.getByElement( editor.document.getById( id ) );
-
-	if ( widget && byElement ) {
-		return widget.element.$.id == id ? widget : null;
-	}
-
-	return widget;
 }
 
 function setDataHelper( editor: any, data: Array<string>, done: Function ) {
@@ -112,14 +89,6 @@ function setDataHelper( editor: any, data: Array<string>, done: Function ) {
 	} else {
 		setTimeout( done, 100 );
 	}
-}
-
-function getDragEventTarget( widgetOrNode ) {
-	if ( !widgetOrNode.dragHandlerContainer ) {
-		return widgetOrNode;
-	}
-
-	return widgetOrNode.dragHandlerContainer.findOne( 'img' );
 }
 
 function mockNativeDataTransfer() {


### PR DESCRIPTION
Hello everyone,

I have been extending the component with a few events CKEditor is aware of. Currently the tests are failing because it seems that some resources are not loaded. I would like to fix this as well, but I am not really sure how and I would appreciate any advice.

Here the test results (please note that I stripped the trace a bit):

CKEditorComponent type="divarea" when component is ready editor event paste should emit component paste

```
TypeError: Cannot read property 'dataTransfer' of undefined
    at a.<anonymous> (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:692:494)
    at a.h (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:10:70)
    at a.<anonymous> (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:11:433)
    at a.window.CKEDITOR.window.CKEDITOR.dom.CKEDITOR.editor.CKEDITOR.editor.fire (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:13:97)
    at UserContext.<anonymous> (http://localhost:9876/_karma_webpack_/webpack:/src/ckeditor/ckeditor.component.spec.ts:270:26)
```

CKEditorComponent type="divarea" when component is ready editor event dragend should emit component dragend

```
TypeError: Cannot read property '$' of undefined
    at Object.initDragDataTransfer (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:705:241)
    at a.h (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:10:70)
    at a.<anonymous> (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:11:433)
    at a.window.CKEDITOR.window.CKEDITOR.dom.CKEDITOR.editor.CKEDITOR.editor.fire (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:13:97)
    at UserContext.<anonymous> (http://localhost:9876/_karma_webpack_/webpack:/src/ckeditor/ckeditor.component.spec.ts:281:26)
```

CKEditorComponent type="divarea" when component is ready editor event dragstart should emit component dragstart

```
TypeError: Cannot read property '$' of undefined
    at Object.initDragDataTransfer (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:705:241)
    at a.<anonymous> (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:688:145)
    at a.h (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:10:70)
    at a.<anonymous> (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:11:433)
    at a.window.CKEDITOR.window.CKEDITOR.dom.CKEDITOR.editor.CKEDITOR.editor.fire (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:13:97)
    at UserContext.<anonymous> (http://localhost:9876/_karma_webpack_/webpack:/src/ckeditor/ckeditor.component.spec.ts:292:26)
```

CKEditorComponent type="divarea" when component is ready editor event drop should emit component drop

```
TypeError: Cannot read property '$' of undefined
    at Object.initDragDataTransfer (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:705:241)
    at a.h (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:10:70)
    at a.<anonymous> (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:11:433)
    at a.window.CKEDITOR.window.CKEDITOR.dom.CKEDITOR.editor.CKEDITOR.editor.fire (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:13:97)
    at UserContext.<anonymous> (http://localhost:9876/_karma_webpack_/webpack:/src/ckeditor/ckeditor.component.spec.ts:303:26)
```

CKEditorComponent type="divarea" when component is ready editor event fileUploadRequest should emit component fileUploadRequest

```
TypeError: Cannot read property 'fileLoader' of undefined
    at a.<anonymous> (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:824:381)
    at a.h (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:10:70)
    at a.<anonymous> (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:11:433)
    at a.window.CKEDITOR.window.CKEDITOR.dom.CKEDITOR.editor.CKEDITOR.editor.fire (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:13:97)
    at UserContext.<anonymous> (http://localhost:9876/_karma_webpack_/webpack:/src/ckeditor/ckeditor.component.spec.ts:317:26)
```

CKEditorComponent type="divarea" when component is ready editor event fileUploadResponse should emit component fileUploadResponse

```
TypeError: Cannot read property 'fileLoader' of undefined
    at a.<anonymous> (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:825:390)
    at a.h (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:10:70)
    at a.<anonymous> (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:11:433)
    at a.window.CKEDITOR.window.CKEDITOR.dom.CKEDITOR.editor.CKEDITOR.editor.fire (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:13:97)
    at UserContext.<anonymous> (http://localhost:9876/_karma_webpack_/webpack:/src/ckeditor/ckeditor.component.spec.ts:331:26)
```

CKEditorComponent type="inline" when component is ready editor event paste should emit component paste

```
TypeError: Cannot read property 'dataTransfer' of undefined
    at a.<anonymous> (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:692:494)
    at a.h (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:10:70)
    at a.<anonymous> (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:11:433)
    at a.window.CKEDITOR.window.CKEDITOR.dom.CKEDITOR.editor.CKEDITOR.editor.fire (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:13:97)
    at UserContext.<anonymous> (http://localhost:9876/_karma_webpack_/webpack:/src/ckeditor/ckeditor.component.spec.ts:270:26)
```

CKEditorComponent type="inline" when component is ready editor event dragend should emit component dragend

```
TypeError: Cannot read property '$' of undefined
    at Object.initDragDataTransfer (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:705:241)
    at a.h (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:10:70)
    at a.<anonymous> (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:11:433)
    at a.window.CKEDITOR.window.CKEDITOR.dom.CKEDITOR.editor.CKEDITOR.editor.fire (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:13:97)
    at UserContext.<anonymous> (http://localhost:9876/_karma_webpack_/webpack:/src/ckeditor/ckeditor.component.spec.ts:281:26)
```

CKEditorComponent type="inline" when component is ready editor event dragstart should emit component dragstart

```
TypeError: Cannot read property '$' of undefined
    at Object.initDragDataTransfer (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:705:241)
    at a.<anonymous> (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:688:145)
    at a.h (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:10:70)
    at a.<anonymous> (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:11:433)
    at a.window.CKEDITOR.window.CKEDITOR.dom.CKEDITOR.editor.CKEDITOR.editor.fire (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:13:97)
    at UserContext.<anonymous> (http://localhost:9876/_karma_webpack_/webpack:/src/ckeditor/ckeditor.component.spec.ts:292:26)
```

CKEditorComponent type="inline" when component is ready editor event drop should emit component drop

```
TypeError: Cannot read property '$' of undefined
    at Object.initDragDataTransfer (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:705:241)
    at a.h (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:10:70)
    at a.<anonymous> (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:11:433)
    at a.window.CKEDITOR.window.CKEDITOR.dom.CKEDITOR.editor.CKEDITOR.editor.fire (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:13:97)
    at UserContext.<anonymous> (http://localhost:9876/_karma_webpack_/webpack:/src/ckeditor/ckeditor.component.spec.ts:303:26)
```

CKEditorComponent type="inline" when component is ready editor event fileUploadRequest should emit component fileUploadRequest

```
TypeError: Cannot read property 'fileLoader' of undefined
    at a.<anonymous> (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:824:381)
    at a.h (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:10:70)
    at a.<anonymous> (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:11:433)
    at a.window.CKEDITOR.window.CKEDITOR.dom.CKEDITOR.editor.CKEDITOR.editor.fire (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:13:97)
```

CKEditorComponent type="inline" when component is ready editor event fileUploadResponse should emit component fileUploadResponse

```
TypeError: Cannot read property 'fileLoader' of undefined
    at a.<anonymous> (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:825:390)
    at a.h (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:10:70)
    at a.<anonymous> (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:11:433)
    at a.window.CKEDITOR.window.CKEDITOR.dom.CKEDITOR.editor.CKEDITOR.editor.fire (https://cdn.ckeditor.com/4.11.4/standard-all/ckeditor.js:13:97)
    at UserContext.<anonymous> (http://localhost:9876/_karma_webpack_/webpack:/src/ckeditor/ckeditor.component.spec.ts:331:26)
```

Are those errors the reason why they have not been added from beginning?

Closes #7.