### PR TITLE
Enable classic editor

### DIFF
--- a/src/app/demo-form/demo-form.component.spec.ts
+++ b/src/app/demo-form/demo-form.component.spec.ts
@@ -12,9 +12,7 @@ import { By } from '@angular/platform-browser';
 import { CKEditorComponent } from '../../ckeditor/ckeditor.component';
 import { DebugElement } from '@angular/core';
 
-import { TestTools } from '../../test.tools';
-
-const whenEvent = TestTools.whenEvent;
+import { whenEvent } from '../../test.tools';
 
 describe( 'DemoFormComponent', () => {
 	let component: DemoFormComponent,

--- a/src/app/demo-form/demo-form.component.spec.ts
+++ b/src/app/demo-form/demo-form.component.spec.ts
@@ -91,15 +91,13 @@ describe( 'DemoFormComponent', () => {
 	} );
 
 	it( 'when reset button is clicked should reset form', done => {
-		fixture.whenStable().then( () => {
-			const resetButton: HTMLButtonElement = fixture.debugElement.query( By.css( 'button[type=reset]' ) ).nativeElement;
-			resetButton.click();
+		const resetButton: HTMLButtonElement = fixture.debugElement.query( By.css( 'button[type=reset]' ) ).nativeElement;
+		resetButton.click();
 
-			fixture.detectChanges();
-			expect( component.formDataPreview ).toEqual( '{"name":null,"surname":null,"description":null}' );
+		fixture.detectChanges();
+		expect( component.formDataPreview ).toEqual( '{"name":null,"surname":null,"description":null}' );
 
-			done();
-		} );
+		done();
 	} );
 
 	[ {

--- a/src/app/demo-form/demo-form.component.spec.ts
+++ b/src/app/demo-form/demo-form.component.spec.ts
@@ -25,11 +25,10 @@ describe( 'DemoFormComponent', () => {
 		TestBed.configureTestingModule( {
 			declarations: [ DemoFormComponent ],
 			imports: [ FormsModule, CKEditorModule ]
-		} )
-			.compileComponents();
+		} ).compileComponents();
 	} ) );
 
-	beforeEach( ( done ) => {
+	beforeEach( done => {
 		fixture = TestBed.createComponent( DemoFormComponent );
 		component = fixture.componentInstance;
 		debugElement = fixture.debugElement.query( By.directive( CKEditorComponent ) );
@@ -43,7 +42,7 @@ describe( 'DemoFormComponent', () => {
 		whenEvent( 'ready', ckeditorComponent ).then( done );
 	} );
 
-	afterEach( ( done ) => {
+	afterEach( done => {
 		if ( ckeditorComponent.instance ) {
 			ckeditorComponent.instance.once( 'destroy', done );
 		}
@@ -74,7 +73,7 @@ describe( 'DemoFormComponent', () => {
 	} );
 
 	// This test passes when run solo or testes as first, but throws a type error when run after other tests.
-	it( 'when change event is emitted should show form data preview', ( done: Function ) => {
+	it( 'when change event is emitted should show form data preview', done => {
 		whenEvent( 'change', ckeditorComponent ).then( () => {
 			fixture.detectChanges();
 			expect( component.formDataPreview ).toEqual( '{"name":"John","surname":"Doe","description":"<p>An unidentified person</p>\\n"}' );
@@ -85,7 +84,7 @@ describe( 'DemoFormComponent', () => {
 
 	} );
 
-	it( 'when reset button is clicked should reset form', ( done: Function ) => {
+	it( 'when reset button is clicked should reset form', done => {
 		fixture.whenStable().then( () => {
 			const resetButton: HTMLButtonElement = fixture.debugElement.query( By.css( 'button[type=reset]' ) ).nativeElement;
 			resetButton.click();

--- a/src/app/demo-form/demo-form.component.spec.ts
+++ b/src/app/demo-form/demo-form.component.spec.ts
@@ -19,7 +19,8 @@ describe( 'DemoFormComponent', () => {
 		fixture: ComponentFixture<DemoFormComponent>,
 		ckeditorComponent: CKEditorComponent,
 		debugElement: DebugElement,
-		originalTimeout: number;
+		originalTimeout: number,
+		config: Object;
 
 	beforeEach( async( () => {
 		TestBed.configureTestingModule( {
@@ -34,6 +35,8 @@ describe( 'DemoFormComponent', () => {
 		debugElement = fixture.debugElement.query( By.directive( CKEditorComponent ) );
 		ckeditorComponent = debugElement.componentInstance;
 
+		ckeditorComponent.config = config;
+
 		fixture.detectChanges();
 
 		originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
@@ -46,6 +49,9 @@ describe( 'DemoFormComponent', () => {
 		if ( ckeditorComponent.instance ) {
 			ckeditorComponent.instance.once( 'destroy', done );
 		}
+
+		config = {};
+
 		fixture.destroy();
 
 		jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
@@ -97,24 +103,27 @@ describe( 'DemoFormComponent', () => {
 	} );
 
 	[ {
-		config: undefined,
+		newConfig: {},
 		msg: 'with undo plugin'
 	}, {
-		config: { removePlugins: 'undo' },
+		newConfig: { removePlugins: 'undo' },
 		msg: 'without undo plugin'
-	}].forEach( ( { config, msg } ) => {
-		describe( msg, () => {
-			beforeEach( () => {
-				ckeditorComponent.config = config;
-				fixture.detectChanges();
+	}].forEach( ( { newConfig, msg } ) => {
+		describe( 'should emit onChange event', () => {
+			beforeAll( () => {
+				config = newConfig;
 			} );
-			it( 'should emit onChange event', () => {
+
+			it( msg, done => {
 				const spy = spyOn( ckeditorComponent, 'onChange' );
 
-				ckeditorComponent.instance.setData( '<p>An unidentified person</p>' );
-				fixture.detectChanges();
+				whenEvent( 'dataChange', ckeditorComponent ).then( () => {
+					fixture.detectChanges();
+					expect( spy ).toHaveBeenCalledTimes( 1 );
+					done();
+				} );
 
-				expect( spy ).toHaveBeenCalledTimes( 1 );
+				ckeditorComponent.instance.setData( '<p>An unidentified person</p>' );
 			} );
 		} );
 	} );

--- a/src/app/simple-usage/simple-usage.component.html
+++ b/src/app/simple-usage/simple-usage.component.html
@@ -3,13 +3,13 @@
 <p><strong>Note:</strong> Open the console for additional logs.</p>
 
 <div *ngFor="let editor of editors">
-	<h3>{{ editor | titlecase }} Editor:</h3>
+	<h3>{{ editor }} Editor:</h3>
 	<ckeditor
 		*ngIf="!isRemoved"
 		[(data)]="editorData"
 		[readOnly]="isReadOnly"
 		[hidden]="isHidden"
-		id="{{ editor }}-editor"
+		type="{{ editor | lowercase }}"
 
 		(ready)="onReady( $event, editor )"
 		(change)="onChange( $event, editor )"

--- a/src/app/simple-usage/simple-usage.component.html
+++ b/src/app/simple-usage/simple-usage.component.html
@@ -2,43 +2,23 @@
 
 <p><strong>Note:</strong> Open the console for additional logs.</p>
 
-<h3>Divarea editor:</h3>
-<ckeditor
-	*ngIf="!isRemoved"
-	[(data)]="editorData"
-	[readOnly]="isReadOnly"
-	[hidden]="isHidden"
-	#divarea
-	id="divarea-editor"
-	name="divarea-editor"
-
-	(ready)="onReady( $event, 'Divarea' )"
-	(change)="onChange( $event, 'Divarea' )"
-	(focus)="onFocus( $event, 'Divarea' )"
-	(blur)="onBlur( $event, 'Divarea' )">
-</ckeditor>
-
-<h3>Inline editor:</h3>
-<div style="border: solid 1px black;">
+<div *ngFor="let editor of editors">
+	<h3>{{ editor | titlecase }} Editor:</h3>
 	<ckeditor
 		*ngIf="!isRemoved"
-		[hidden]="isHidden"
 		[(data)]="editorData"
 		[readOnly]="isReadOnly"
-		#inline
+		[hidden]="isHidden"
+		id="{{ editor }}-editor"
 
-		id="inline-editor"
-		name="inline-editor"
-
-		type="inline"
-
-		(ready)="onReady( $event, 'Inline' )"
-		(change)="onChange( $event, 'Inline' )"
-		(focus)="onFocus( $event, 'Inline' )"
-		(blur)="onBlur( $event, 'Inline' )">
+		(ready)="onReady( $event, editor )"
+		(change)="onChange( $event, editor )"
+		(focus)="onFocus( $event, editor )"
+		(blur)="onBlur( $event, editor )">
 	</ckeditor>
 </div>
-<p>Note: both editors have it's data synchronized, so every change in one of editors propagates to another.</p>
+
+<p>Note: editors have it's data synchronized, so every change in one of editors propagates to another.</p>
 
 <h4>Component controls:</h4>
 

--- a/src/app/simple-usage/simple-usage.component.spec.ts
+++ b/src/app/simple-usage/simple-usage.component.spec.ts
@@ -13,6 +13,7 @@ import { DebugElement } from '@angular/core';
 
 import { whenEvent } from '../../test.tools';
 import { FormsModule } from '@angular/forms';
+import { getEditorNamespace } from '../../ckeditor/ckeditor.helpers';
 import Spy = jasmine.Spy;
 
 describe( 'SimpleUsageComponent', () => {
@@ -91,13 +92,21 @@ describe( 'SimpleUsageComponent', () => {
 		} );
 
 		it( 'should be synced with editorData property', () => {
-			component.editorData = '<p>foo</p>\n';
+			getEditorNamespace( ckeditorComponents[ 0 ].editorUrl )
+				.then( CKEDITOR => {
+					if ( CKEDITOR.env.ie ) {
+						// Ignore on IE11/Edge for now since it throws "Permission denied" error (#72).
+						pending();
+					} else {
+						component.editorData = '<p>foo</p>\n';
 
-			fixture.detectChanges();
+						fixture.detectChanges();
 
-			each( ckeditorComponent => {
-				expect( ckeditorComponent.data ).toEqual( '<p>foo</p>\n' );
-			} );
+						each( ckeditorComponent => {
+							expect( ckeditorComponent.data ).toEqual( '<p>foo</p>\n' );
+						} );
+					}
+				} );
 		} );
 	} );
 

--- a/src/app/simple-usage/simple-usage.component.spec.ts
+++ b/src/app/simple-usage/simple-usage.component.spec.ts
@@ -11,11 +11,9 @@ import { By } from '@angular/platform-browser';
 import { CKEditorComponent } from '../../ckeditor/ckeditor.component';
 import { DebugElement } from '@angular/core';
 
-import { TestTools } from '../../test.tools';
+import { whenEvent } from '../../test.tools';
 import { FormsModule } from '@angular/forms';
 import Spy = jasmine.Spy;
-
-const whenEvent = TestTools.whenEvent;
 
 describe( 'SimpleUsageComponent', () => {
 	let component: SimpleUsageComponent,
@@ -110,34 +108,38 @@ describe( 'SimpleUsageComponent', () => {
 		} );
 
 		it( 'ready should be called on ckeditorComponent.ready()', () => {
-			each( ckeditorComponent => {
+			each( ( ckeditorComponent, name ) => {
 				ckeditorComponent.ready.emit();
 
-				expect( spy ).toHaveBeenCalledWith( 'Divarea editor is ready.' );
+				expect( spy ).toHaveBeenCalledWith( `${ name } editor is ready.` );
 			} );
 		} );
 
 		it( 'change should be called on ckeditorComponent.change()', () => {
-			each( ckeditorComponent => {
+			each( ( ckeditorComponent, name ) => {
 				ckeditorComponent.change.emit();
 
-				expect( spy ).toHaveBeenCalledWith( 'Divarea editor model changed.' );
+				expect( spy ).toHaveBeenCalledWith( `${ name } editor model changed.` );
 			} );
 		} );
 
 		it( 'focus should be called on ckeditorComponent.focus()', () => {
-			each( ckeditorComponent => {
+			each( ( ckeditorComponent, name ) => {
 				ckeditorComponent.focus.emit();
 
-				expect( spy ).toHaveBeenCalledWith( 'Focused divarea editing view.' );
+				name = name.toLowerCase();
+
+				expect( spy ).toHaveBeenCalledWith( `Focused ${ name } editing view.` );
 			} );
 		} );
 
 		it( 'blur should be called on ckeditorComponent.blur()', () => {
-			each( ckeditorComponent => {
+			each( ( ckeditorComponent, name ) => {
 				ckeditorComponent.blur.emit();
 
-				expect( spy ).toHaveBeenCalledWith( 'Blurred divarea editing view.' );
+				name = name.toLowerCase();
+
+				expect( spy ).toHaveBeenCalledWith( `Blurred ${ name } editing view.` );
 			} );
 		} );
 	} );
@@ -147,6 +149,12 @@ describe( 'SimpleUsageComponent', () => {
 	}
 
 	function each( callback ) {
-		ckeditorComponents.forEach( item => callback( item ) );
+		ckeditorComponents.forEach( ( item ) => {
+			let name: String = item.type;
+
+			name = name[ 0 ].toUpperCase() + name.slice( 1 );
+
+			callback( item, name );
+		} );
 	}
 } );

--- a/src/app/simple-usage/simple-usage.component.spec.ts
+++ b/src/app/simple-usage/simple-usage.component.spec.ts
@@ -29,7 +29,7 @@ describe( 'SimpleUsageComponent', () => {
 		} ).compileComponents();
 	} ) );
 
-	beforeEach( ( done ) => {
+	beforeEach( done => {
 		fixture = TestBed.createComponent( SimpleUsageComponent );
 		component = fixture.componentInstance;
 
@@ -44,9 +44,9 @@ describe( 'SimpleUsageComponent', () => {
 		whenEach( ckeditorComponent => whenEvent( 'ready', ckeditorComponent ) ).then( done );
 	} );
 
-	afterEach( ( done ) => {
+	afterEach( done => {
 		whenEach( ckeditorComponent =>
-			new Promise( ( res ) => {
+			new Promise( res => {
 				if ( ckeditorComponent.instance ) {
 					ckeditorComponent.instance.once( 'destroy', res );
 				}
@@ -149,7 +149,7 @@ describe( 'SimpleUsageComponent', () => {
 	}
 
 	function each( callback ) {
-		ckeditorComponents.forEach( ( item ) => {
+		ckeditorComponents.forEach( item => {
 			let name: String = item.type;
 
 			name = name[ 0 ].toUpperCase() + name.slice( 1 );

--- a/src/app/simple-usage/simple-usage.component.ts
+++ b/src/app/simple-usage/simple-usage.component.ts
@@ -19,7 +19,7 @@ export class SimpleUsageComponent {
 While it’s also nice to learn about cultures online or from books, nothing comes close to experiencing cultural diversity in person.
 You learn to appreciate each and every single one of the differences while you become more culturally fluid.</p>`;
 
-	editors = [ 'classic', 'divarea', 'inline' ];
+	editors = [ 'Classic', 'Divarea', 'Inline' ];
 
 	isHidden = false;
 

--- a/src/app/simple-usage/simple-usage.component.ts
+++ b/src/app/simple-usage/simple-usage.component.ts
@@ -19,6 +19,8 @@ export class SimpleUsageComponent {
 While it’s also nice to learn about cultures online or from books, nothing comes close to experiencing cultural diversity in person.
 You learn to appreciate each and every single one of the differences while you become more culturally fluid.</p>`;
 
+	editors = [ 'classic', 'divarea', 'inline' ];
+
 	isHidden = false;
 
 	isRemoved = false;

--- a/src/ckeditor/ckeditor.component.spec.ts
+++ b/src/ckeditor/ckeditor.component.spec.ts
@@ -5,7 +5,7 @@
 
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { CKEditorComponent } from './ckeditor.component';
-import { whenEvent, whenDataReady } from '../test.tools';
+import { whenEvent, whenDataReady, setDataMultipleTimes } from '../test.tools';
 import { CKEditor4 } from './ckeditor';
 import EditorType = CKEditor4.EditorType;
 
@@ -53,7 +53,7 @@ describe( 'CKEditorComponent', () => {
 					fixture.detectChanges();
 
 					return whenEvent( 'ready', component ).then( () => {
-						expect( component.instance.elementMode ).toEqual( editorType == 'divarea' ? 1 : 3 );
+						expect( component.instance.elementMode ).toEqual( editorType == 'inline' ? 3 : 1 );
 					} );
 				} );
 
@@ -183,14 +183,19 @@ describe( 'CKEditorComponent', () => {
 						expect( component.instance.plugins.undo ).not.toBeUndefined();
 					} );
 
-					it( 'should register changes', () => {
+					it( 'should register changes', async done => {
 						const spy = jasmine.createSpy();
 
 						component.registerOnChange( spy );
-						component.instance.setData( '<p>Hello World!</p>' );
-						component.instance.setData( '</p>I am CKEditor for Angular!</p>' );
 
-						expect( spy ).toHaveBeenCalledTimes( 2 );
+						setDataMultipleTimes( component.instance, [
+							'<p>Hello World!</p>',
+							'<p>I am CKEditor for Angular!</p>'
+						] ).then( () => {
+							expect( spy ).toHaveBeenCalledTimes( 2 );
+
+							done();
+						} );
 					} );
 				} );
 
@@ -207,14 +212,19 @@ describe( 'CKEditorComponent', () => {
 						expect( component.instance.plugins.undo ).toBeUndefined();
 					} );
 
-					it( 'should register changes without undo plugin', () => {
+					it( 'should register changes without undo plugin', async done => {
 						const spy = jasmine.createSpy();
 
 						component.registerOnChange( spy );
-						component.instance.setData( '<p>Hello World!</p>' );
-						component.instance.setData( '</p>I am CKEditor for Angular!</p>' );
 
-						expect( spy ).toHaveBeenCalledTimes( 2 );
+						setDataMultipleTimes( component.instance, [
+							'<p>Hello World!</p>',
+							'<p>I am CKEditor for Angular!</p>'
+						] ).then( () => {
+							expect( spy ).toHaveBeenCalledTimes( 2 );
+
+							done();
+						} );
 					} );
 				} );
 			} );
@@ -346,17 +356,18 @@ describe( 'CKEditorComponent', () => {
 						expect( spy ).toHaveBeenCalled();
 					} );
 
-					it( 'onChange callback should be called when editor model changes', () => {
+					it( 'onChange callback should be called when editor model changes', async done => {
 						fixture.detectChanges();
 
 						const spy = jasmine.createSpy();
 						component.registerOnChange( spy );
 
-						component.instance.setData( 'initial' );
-						component.instance.setData( 'initial' );
-						component.instance.setData( 'modified' );
-
-						expect( spy ).toHaveBeenCalledTimes( 2 );
+						setDataMultipleTimes( component.instance, [
+							'initial', 'initial', 'modified'
+						] ).then( () => {
+							expect( spy ).toHaveBeenCalledTimes( 2 );
+							done();
+						} );
 					} );
 				} );
 			} );

--- a/src/ckeditor/ckeditor.component.spec.ts
+++ b/src/ckeditor/ckeditor.component.spec.ts
@@ -257,35 +257,31 @@ describe( 'CKEditorComponent', () => {
 					const data = '<b>foo</b>',
 						expected = '<p><strong>foo</strong></p>\n';
 
-					it( 'should be configurable at the start of the component', done => {
+					it( 'should be configurable at the start of the component', async done => {
 						fixture.detectChanges();
 
-						whenDataReady( component.instance ).then( () => {
-							expect( component.data ).toEqual( expected );
-							expect( component.instance.getData() ).toEqual( expected );
-							done();
-						} );
+						await whenDataReady( component.instance, () => component.data = data );
 
-						component.data = data;
+						expect( component.data ).toEqual( expected );
+						expect( component.instance.getData() ).toEqual( expected );
+
+						done();
 					} );
 
-					it( 'should be writeable by ControlValueAccessor', done => {
+					it( 'should be writeable by ControlValueAccessor', async done => {
 						fixture.detectChanges();
 
 						const editor = component.instance;
 
-						whenDataReady( editor ).then( () => {
-							expect( component.instance.getData() ).toEqual( expected );
+						await whenDataReady( editor, () => component.writeValue( data ) );
 
-							whenDataReady( editor ).then( () => {
-								expect( component.instance.getData() ).toEqual( '<p><em>baz</em></p>\n' );
-								done();
-							} );
+						expect( component.instance.getData() ).toEqual( expected );
 
-							component.writeValue( '<p><i>baz</i></p>' );
-						} );
+						await whenDataReady( editor, () => component.writeValue( '<p><i>baz</i></p>' ) );
 
-						component.writeValue( data );
+						expect( component.instance.getData() ).toEqual( '<p><em>baz</em></p>\n' );
+
+						done();
 					} );
 				} );
 

--- a/src/ckeditor/ckeditor.component.spec.ts
+++ b/src/ckeditor/ckeditor.component.spec.ts
@@ -5,11 +5,9 @@
 
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { CKEditorComponent } from './ckeditor.component';
-import { TestTools } from '../test.tools';
+import { whenEvent, whenDataReady } from '../test.tools';
 import { CKEditor4 } from './ckeditor';
 import EditorType = CKEditor4.EditorType;
-
-const whenEvent = TestTools.whenEvent;
 
 declare var CKEDITOR: any;
 
@@ -262,11 +260,11 @@ describe( 'CKEditorComponent', () => {
 					it( 'should be configurable at the start of the component', done => {
 						fixture.detectChanges();
 
-						component.instance.once( 'dataReady', () => {
+						whenDataReady( component.instance ).then( () => {
 							expect( component.data ).toEqual( expected );
 							expect( component.instance.getData() ).toEqual( expected );
 							done();
-						}, null, null, 9999 );
+						} );
 
 						component.data = data;
 					} );
@@ -276,15 +274,16 @@ describe( 'CKEditorComponent', () => {
 
 						const editor = component.instance;
 
-						editor.once( 'dataReady', () => {
+						whenDataReady( editor ).then( () => {
 							expect( component.instance.getData() ).toEqual( expected );
 
-							editor.once( 'dataReady', () => {
+							whenDataReady( editor ).then( () => {
 								expect( component.instance.getData() ).toEqual( '<p><em>baz</em></p>\n' );
 								done();
 							} );
+
 							component.writeValue( '<p><i>baz</i></p>' );
-						}, null, null, 9999 );
+						} );
 
 						component.writeValue( data );
 					} );

--- a/src/ckeditor/ckeditor.component.spec.ts
+++ b/src/ckeditor/ckeditor.component.spec.ts
@@ -59,6 +59,13 @@ describe( 'CKEditorComponent', () => {
 					} );
 				} );
 
+				it( 'should have proper editor type', () => {
+					whenEvent( 'ready', component ).then( () => {
+						fixture.detectChanges();
+						expect( component.instance.editable().isInline() ).toBe( component.type !== EditorType.CLASSIC );
+					} );
+				} );
+
 				it( 'should emit ready event', () => {
 					const spy = jasmine.createSpy();
 					component.ready.subscribe( spy );

--- a/src/ckeditor/ckeditor.component.spec.ts
+++ b/src/ckeditor/ckeditor.component.spec.ts
@@ -18,8 +18,7 @@ describe( 'CKEditorComponent', () => {
 	beforeEach( async( () => {
 		TestBed.configureTestingModule( {
 			declarations: [ CKEditorComponent ]
-		} )
-			.compileComponents();
+		} ).compileComponents();
 	} ) );
 
 	beforeEach( () => {
@@ -35,7 +34,7 @@ describe( 'CKEditorComponent', () => {
 		EditorType.DIVAREA,
 		EditorType.INLINE,
 		EditorType.CLASSIC
-	].forEach( ( editorType ) => {
+	].forEach( editorType => {
 		describe( `type="${editorType}"`, () => {
 			beforeEach( () => {
 				component.type = editorType;
@@ -146,7 +145,7 @@ describe( 'CKEditorComponent', () => {
 				}
 
 				describe( 'when set with config', () => {
-					beforeEach( ( done ) => {
+					beforeEach( done => {
 						component.config = {
 							readOnly: true,
 							width: 1000,
@@ -206,7 +205,7 @@ describe( 'CKEditorComponent', () => {
 			} );
 
 			describe( 'when component is ready', () => {
-				beforeEach( ( done ) => {
+				beforeEach( done => {
 					fixture.detectChanges();
 					whenEvent( 'ready', component ).then( done );
 				} );

--- a/src/ckeditor/ckeditor.component.spec.ts
+++ b/src/ckeditor/ckeditor.component.spec.ts
@@ -101,55 +101,57 @@ describe( 'CKEditorComponent', () => {
 					} );
 				} );
 
-				if ( editorType === EditorType.DIVAREA ) {
-					[ {
-						config: undefined,
-						msg: 'without config',
-						warn: false
-					}, {
-						config: { extraPlugins: 'basicstyles,divarea,link' },
-						msg: 'config.extraPlugins defined as a string',
-						warn: false
-					}, {
-						config: { extraPlugins: [ 'basicstyles', 'divarea', 'link' ] },
-						msg: 'config.extraPlugins defined as an array',
-						warn: false
-					}, {
-						config: { removePlugins: 'basicstyles,divarea,link,divarea' },
-						msg: 'config.removePlugins defined as a string',
-						warn: true
-					}, {
-						config: { removePlugins: [ 'basicstyles', 'divarea', 'link', 'divarea' ] },
-						msg: 'config.removePlugins defined as an array',
-						warn: true
-					} ].forEach( ( { config, msg, warn } ) => {
-						describe( msg, () => {
-							beforeEach( () => {
-								component.config = config;
-							} );
+				const isDivarea = editorType === EditorType.DIVAREA;
 
-							it( `console ${warn ? 'should' : 'shouldn\'t'} warn`, () => {
-								const spy = spyOn( console, 'warn' );
+				[ {
+					config: undefined,
+					msg: 'without config',
+					warn: false
+				}, {
+					config: { extraPlugins: 'basicstyles,divarea,link' },
+					msg: 'config.extraPlugins defined as a string',
+					warn: false
+				}, {
+					config: { extraPlugins: [ 'basicstyles', 'divarea', 'link' ] },
+					msg: 'config.extraPlugins defined as an array',
+					warn: false
+				}, {
+					config: { removePlugins: 'basicstyles,divarea,link,divarea' },
+					msg: 'config.removePlugins defined as a string',
+					warn: isDivarea
+				}, {
+					config: { removePlugins: [ 'basicstyles', 'divarea', 'link', 'divarea' ] },
+					msg: 'config.removePlugins defined as an array',
+					warn: isDivarea
+				} ].forEach( ( { config, msg, warn } ) => {
+					describe( msg, () => {
+						beforeEach( () => {
+							component.config = config;
+						} );
 
+						it( `console ${warn ? 'should' : 'shouldn\'t'} warn`, () => {
+							const spy = spyOn( console, 'warn' );
+
+							return whenEvent( 'ready', component ).then( () => {
 								fixture.detectChanges();
 
-								return whenEvent( 'ready', component ).then( () => {
-									warn
-										? expect( spy ).toHaveBeenCalled()
-										: expect( spy ).not.toHaveBeenCalled();
-								} );
+								warn
+									? expect( spy ).toHaveBeenCalled()
+									: expect( spy ).not.toHaveBeenCalled();
 							} );
+						} );
 
-							it( 'editor should use divarea plugin', () => {
+						it( `editor ${ isDivarea ? 'should' : 'shouldn\'t' } use divarea plugin`, () => {
+							return whenEvent( 'ready', component ).then( ( { editor } ) => {
 								fixture.detectChanges();
 
-								return whenEvent( 'ready', component ).then( ( { editor } ) => {
-									expect( editor.plugins.divarea ).not.toBeUndefined();
-								} );
+								isDivarea
+									? expect( editor.plugins.divarea ).not.toBeUndefined()
+									: expect( editor.plugins.divarea ).toBeUndefined();
 							} );
 						} );
 					} );
-				}
+				} );
 
 				describe( 'when set with config', () => {
 					beforeEach( done => {

--- a/src/ckeditor/ckeditor.component.spec.ts
+++ b/src/ckeditor/ckeditor.component.spec.ts
@@ -102,7 +102,10 @@ describe( 'CKEditorComponent', () => {
 						fixture.detectChanges();
 
 						return whenEvent( 'ready', component ).then( () => {
-							expect( fixture.nativeElement.lastChild.tagName ).toEqual( 'DIV' );
+							// IE browsers use SPAN elements instead of DIV as a main CKEditor wrapper
+							// when replace() method for creation is used.
+							const expectedElement = CKEDITOR.env.ie && method !== 'inline' ? 'SPAN' : 'DIV';
+							expect( fixture.nativeElement.lastChild.tagName ).toEqual( expectedElement );
 						} );
 					} );
 				} );

--- a/src/ckeditor/ckeditor.component.spec.ts
+++ b/src/ckeditor/ckeditor.component.spec.ts
@@ -5,12 +5,13 @@
 
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { CKEditorComponent } from './ckeditor.component';
-
 import { TestTools } from '../test.tools';
 import { CKEditor4 } from './ckeditor';
 import EditorType = CKEditor4.EditorType;
 
 const whenEvent = TestTools.whenEvent;
+
+declare var CKEDITOR: any;
 
 describe( 'CKEditorComponent', () => {
 	let component: CKEditorComponent,
@@ -32,14 +33,18 @@ describe( 'CKEditorComponent', () => {
 		fixture.destroy();
 	} );
 
-	[ EditorType.DIVAREA, EditorType.INLINE ].forEach( ( editorType ) => {
+	[
+		EditorType.DIVAREA,
+		EditorType.INLINE,
+		EditorType.CLASSIC
+	].forEach( ( editorType ) => {
 		describe( `type="${editorType}"`, () => {
 			beforeEach( () => {
 				component.type = editorType;
 			} );
 
 			describe( 'on initialization', () => {
-				const method = editorType === 'divarea' ? 'replace' : 'inline';
+				const method = editorType === 'inline' ? 'inline' : 'replace';
 
 				it( `should create editor with CKEDITOR.${method}`, () => {
 					fixture.detectChanges();
@@ -92,54 +97,55 @@ describe( 'CKEditorComponent', () => {
 					} );
 				} );
 
-				[ {
-					config: undefined,
-					msg: 'without config',
-					warn: false
-				}, {
-					config: { extraPlugins: 'basicstyles,divarea,link' },
-					msg: 'config.extraPlugins defined as a string',
-					warn: false
-				}, {
-					config: { extraPlugins: [ 'basicstyles', 'divarea', 'link' ] },
-					msg: 'config.extraPlugins defined as an array',
-					warn: false
-				}, {
-					config: { removePlugins: 'basicstyles,divarea,link,divarea' },
-					msg: 'config.removePlugins defined as a string',
-					warn: true
-				}, {
-					config: { removePlugins: [ 'basicstyles', 'divarea', 'link', 'divarea' ] },
-					msg: 'config.removePlugins defined as an array',
-					warn: true
-				}
-				].forEach( ( { config, msg, warn } ) => {
-					describe( msg, () => {
-						beforeEach( () => {
-							component.config = config;
-						} );
-
-						it( `console ${warn ? 'should' : 'shouldn\'t'} warn`, () => {
-							const spy = spyOn( console, 'warn' );
-
-							fixture.detectChanges();
-
-							return whenEvent( 'ready', component ).then( () => {
-								warn
-									? expect( spy ).toHaveBeenCalled()
-									: expect( spy ).not.toHaveBeenCalled();
+				if ( editorType === EditorType.DIVAREA ) {
+					[ {
+						config: undefined,
+						msg: 'without config',
+						warn: false
+					}, {
+						config: { extraPlugins: 'basicstyles,divarea,link' },
+						msg: 'config.extraPlugins defined as a string',
+						warn: false
+					}, {
+						config: { extraPlugins: [ 'basicstyles', 'divarea', 'link' ] },
+						msg: 'config.extraPlugins defined as an array',
+						warn: false
+					}, {
+						config: { removePlugins: 'basicstyles,divarea,link,divarea' },
+						msg: 'config.removePlugins defined as a string',
+						warn: true
+					}, {
+						config: { removePlugins: [ 'basicstyles', 'divarea', 'link', 'divarea' ] },
+						msg: 'config.removePlugins defined as an array',
+						warn: true
+					} ].forEach( ( { config, msg, warn } ) => {
+						describe( msg, () => {
+							beforeEach( () => {
+								component.config = config;
 							} );
-						} );
 
-						it( 'editor should use divarea plugin', () => {
-							fixture.detectChanges();
+							it( `console ${warn ? 'should' : 'shouldn\'t'} warn`, () => {
+								const spy = spyOn( console, 'warn' );
 
-							return whenEvent( 'ready', component ).then( ( { editor } ) => {
-								expect( editor.plugins.divarea ).not.toBeUndefined();
+								fixture.detectChanges();
+
+								return whenEvent( 'ready', component ).then( () => {
+									warn
+										? expect( spy ).toHaveBeenCalled()
+										: expect( spy ).not.toHaveBeenCalled();
+								} );
+							} );
+
+							it( 'editor should use divarea plugin', () => {
+								fixture.detectChanges();
+
+								return whenEvent( 'ready', component ).then( ( { editor } ) => {
+									expect( editor.plugins.divarea ).not.toBeUndefined();
+								} );
 							} );
 						} );
 					} );
-				} );
+				}
 
 				describe( 'when set with config', () => {
 					beforeEach( ( done ) => {
@@ -253,23 +259,34 @@ describe( 'CKEditorComponent', () => {
 					const data = '<b>foo</b>',
 						expected = '<p><strong>foo</strong></p>\n';
 
-					it( 'should be configurable at the start of the component', () => {
+					it( 'should be configurable at the start of the component', done => {
 						fixture.detectChanges();
-						component.data = data;
 
-						expect( component.data ).toEqual( expected );
-						expect( component.instance.getData() ).toEqual( expected );
+						component.instance.once( 'dataReady', () => {
+							expect( component.data ).toEqual( expected );
+							expect( component.instance.getData() ).toEqual( expected );
+							done();
+						}, null, null, 9999 );
+
+						component.data = data;
 					} );
 
-					it( 'should be writeable by ControlValueAccessor', () => {
+					it( 'should be writeable by ControlValueAccessor', done => {
 						fixture.detectChanges();
+
+						const editor = component.instance;
+
+						editor.once( 'dataReady', () => {
+							expect( component.instance.getData() ).toEqual( expected );
+
+							editor.once( 'dataReady', () => {
+								expect( component.instance.getData() ).toEqual( '<p><em>baz</em></p>\n' );
+								done();
+							} );
+							component.writeValue( '<p><i>baz</i></p>' );
+						}, null, null, 9999 );
+
 						component.writeValue( data );
-
-						expect( component.instance.getData() ).toEqual( expected );
-
-						component.writeValue( '<p><i>baz</i></p>' );
-
-						expect( component.instance.getData() ).toEqual( '<p><em>baz</em></p>\n' );
 					} );
 				} );
 

--- a/src/ckeditor/ckeditor.component.spec.ts
+++ b/src/ckeditor/ckeditor.component.spec.ts
@@ -82,7 +82,7 @@ describe( 'CKEditorComponent', () => {
 						fixture.detectChanges();
 
 						return whenEvent( 'ready', component ).then( () => {
-							expect( fixture.nativeElement.lastElementChild.firstElementChild.tagName ).toEqual( 'TEXTAREA' );
+							expect( fixture.nativeElement.firstElementChild.tagName ).toEqual( 'TEXTAREA' );
 						} );
 					} );
 				} );

--- a/src/ckeditor/ckeditor.component.spec.ts
+++ b/src/ckeditor/ckeditor.component.spec.ts
@@ -13,7 +13,8 @@ declare var CKEDITOR: any;
 
 describe( 'CKEditorComponent', () => {
 	let component: CKEditorComponent,
-		fixture: ComponentFixture<CKEditorComponent>;
+		fixture: ComponentFixture<CKEditorComponent>,
+		config: Object;
 
 	beforeEach( async( () => {
 		TestBed.configureTestingModule( {
@@ -24,9 +25,14 @@ describe( 'CKEditorComponent', () => {
 	beforeEach( () => {
 		fixture = TestBed.createComponent( CKEditorComponent );
 		component = fixture.componentInstance;
+
+		component.config = config;
+
+		fixture.detectChanges();
 	} );
 
 	afterEach( () => {
+		config = {};
 		fixture.destroy();
 	} );
 
@@ -104,37 +110,37 @@ describe( 'CKEditorComponent', () => {
 				const isDivarea = editorType === EditorType.DIVAREA;
 
 				[ {
-					config: undefined,
+					newConfig: undefined,
 					msg: 'without config',
 					warn: false
 				}, {
-					config: { extraPlugins: 'basicstyles,divarea,link' },
+					newConfig: { extraPlugins: 'basicstyles,divarea,link' },
 					msg: 'config.extraPlugins defined as a string',
 					warn: false
 				}, {
-					config: { extraPlugins: [ 'basicstyles', 'divarea', 'link' ] },
+					newConfig: { extraPlugins: [ 'basicstyles', 'divarea', 'link' ] },
 					msg: 'config.extraPlugins defined as an array',
 					warn: false
 				}, {
-					config: { removePlugins: 'basicstyles,divarea,link,divarea' },
+					newConfig: { removePlugins: 'basicstyles,divarea,link,divarea' },
 					msg: 'config.removePlugins defined as a string',
 					warn: isDivarea
 				}, {
-					config: { removePlugins: [ 'basicstyles', 'divarea', 'link', 'divarea' ] },
+					newConfig: { removePlugins: [ 'basicstyles', 'divarea', 'link', 'divarea' ] },
 					msg: 'config.removePlugins defined as an array',
 					warn: isDivarea
-				} ].forEach( ( { config, msg, warn } ) => {
+				} ].forEach( ( { newConfig, msg, warn } ) => {
 					describe( msg, () => {
-						beforeEach( () => {
-							component.config = config;
+						beforeAll( () => {
+							config = newConfig;
 						} );
 
 						it( `console ${warn ? 'should' : 'shouldn\'t'} warn`, () => {
 							const spy = spyOn( console, 'warn' );
 
-							return whenEvent( 'ready', component ).then( () => {
-								fixture.detectChanges();
+							fixture.detectChanges();
 
+							return whenEvent( 'ready', component ).then( () => {
 								warn
 									? expect( spy ).toHaveBeenCalled()
 									: expect( spy ).not.toHaveBeenCalled();
@@ -142,9 +148,9 @@ describe( 'CKEditorComponent', () => {
 						} );
 
 						it( `editor ${ isDivarea ? 'should' : 'shouldn\'t' } use divarea plugin`, () => {
-							return whenEvent( 'ready', component ).then( ( { editor } ) => {
-								fixture.detectChanges();
+							fixture.detectChanges();
 
+							return whenEvent( 'ready', component ).then( ( { editor } ) => {
 								isDivarea
 									? expect( editor.plugins.divarea ).not.toBeUndefined()
 									: expect( editor.plugins.divarea ).toBeUndefined();

--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -166,11 +166,6 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 	instance: any;
 
 	/**
-	 * Wrapper element used to initialize editor.
-	 */
-	wrapper: HTMLElement;
-
-	/**
 	 * If the component is read–only before the editor instance is created, it remembers that state,
 	 * so the editor can become read–only once it is ready.
 	 */
@@ -232,20 +227,19 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 	}
 
 	private createEditor(): void {
-		const element = this.createInitialElement();
+		const element = document.createElement( this.tagName );
+		this.elementRef.nativeElement.appendChild( element );
 
-		this.config = this.ensureDivareaPlugin( this.config || {} );
+		if ( this.type === CKEditor4.EditorType.DIVAREA ) {
+			this.config = this.ensureDivareaPlugin( this.config || {} );
+		}
 
-		const instance = this.type === CKEditor4.EditorType.INLINE ?
-			CKEDITOR.inline( element, this.config )
+		const instance = this.type === CKEditor4.EditorType.INLINE
+			? CKEDITOR.inline( element, this.config )
 			: CKEDITOR.replace( element, this.config );
 
-		instance.once( 'instanceReady', function( evt ) {
+		instance.once( 'instanceReady', ( evt ) => {
 			this.instance = instance;
-
-			this.wrapper.removeAttribute( 'style' );
-
-			this.elementRef.nativeElement.appendChild( this.wrapper );
 
 			// Read only state may change during instance initialization.
 			this.readOnly = this._readOnly !== null ? this._readOnly : this.instance.readOnly;
@@ -269,7 +263,7 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 			this.ngZone.run( () => {
 				this.ready.emit( evt );
 			} );
-		}, this );
+		} );
 	}
 
 	private subscribe( editor: any ): void {
@@ -357,18 +351,5 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 		}
 
 		return plugins;
-	}
-
-	private createInitialElement(): HTMLElement {
-		// Render editor outside of component so it won't be removed from DOM before `instanceReady`.
-		this.wrapper = document.createElement( 'div' );
-		const element = document.createElement( this.tagName );
-
-		this.wrapper.setAttribute( 'style', 'display:none;' );
-
-		document.body.appendChild( this.wrapper );
-		this.wrapper.appendChild( element );
-
-		return element;
 	}
 }

--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -250,19 +250,24 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 
 			if ( this.data !== null ) {
 				undo && undo.lock();
-				instance.setData( this.data );
 
-				// Locking undoManager prevents 'change' event.
-				// Trigger it manually to updated bound data.
-				if ( this.data !== instance.getData() ) {
-					undo ? instance.fire( 'change' ) : instance.fire( 'dataReady' );
-				}
-				undo && undo.unlock();
+				instance.setData( this.data, { callback: () => {
+					// Locking undoManager prevents 'change' event.
+					// Trigger it manually to updated bound data.
+					if ( this.data !== instance.getData() ) {
+						undo ? instance.fire( 'change' ) : instance.fire( 'dataReady' );
+					}
+					undo && undo.unlock();
+
+					this.ngZone.run( () => {
+						this.ready.emit( evt );
+					} );
+				} } );
+			} else {
+				this.ngZone.run( () => {
+					this.ready.emit( evt );
+				} );
 			}
-
-			this.ngZone.run( () => {
-				this.ready.emit( evt );
-			} );
 		} );
 	}
 

--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -238,7 +238,7 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 			? CKEDITOR.inline( element, this.config )
 			: CKEDITOR.replace( element, this.config );
 
-		instance.once( 'instanceReady', ( evt ) => {
+		instance.once( 'instanceReady', evt => {
 			this.instance = instance;
 
 			// Read only state may change during instance initialization.

--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -62,7 +62,7 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 	 * and https://ckeditor.com/docs/ckeditor4/latest/examples/fixedui.html
 	 * to learn more.
 	 */
-	@Input() type: CKEditor4.EditorType = CKEditor4.EditorType.DIVAREA;
+	@Input() type: CKEditor4.EditorType = CKEditor4.EditorType.CLASSIC;
 
 	/**
 	 * Keeps track of the editor's data.

--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -234,7 +234,7 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 			this.config = this.ensureDivareaPlugin( this.config || {} );
 		}
 
-		const instance = this.type === CKEditor4.EditorType.INLINE
+		const instance: CKEditor4.Editor = this.type === CKEditor4.EditorType.INLINE
 			? CKEDITOR.inline( element, this.config )
 			: CKEDITOR.replace( element, this.config );
 

--- a/src/ckeditor/ckeditor.ts
+++ b/src/ckeditor/ckeditor.ts
@@ -7,11 +7,17 @@
  * Basic typings for the CKEditor4 elements.
  */
 export namespace CKEditor4 {
-
 	/**
 	 * The CKEditor4 editor constructor.
 	 */
 	export interface Config {
+		[ key: string ]: any;
+	}
+
+	/**
+	 * The CKEditor4 editor.
+	 */
+	export interface Editor {
 		[ key: string ]: any;
 	}
 

--- a/src/ckeditor/ckeditor.ts
+++ b/src/ckeditor/ckeditor.ts
@@ -22,7 +22,8 @@ export namespace CKEditor4 {
 	 */
 	export const enum EditorType {
 		DIVAREA = 'divarea',
-		INLINE = 'inline'
+		INLINE = 'inline',
+		CLASSIC = 'classic'
 	}
 
 	/**

--- a/src/test.tools.ts
+++ b/src/test.tools.ts
@@ -1,9 +1,7 @@
 import { CKEditorComponent } from './ckeditor/ckeditor.component';
 
-export class TestTools {
-	static whenEvent( evtName: string, component: CKEditorComponent ) {
-		return new Promise( res => {
-			component[ evtName ].subscribe( res );
-		} );
-	}
+export function whenEvent( evtName: string, component: CKEditorComponent ) {
+	return new Promise( res => {
+		component[ evtName ].subscribe( res );
+	} );
 }

--- a/src/test.tools.ts
+++ b/src/test.tools.ts
@@ -6,10 +6,12 @@ export function whenEvent( evtName: string, component: CKEditorComponent ) {
 	} );
 }
 
-export function whenDataReady( editor: any ) {
+export function whenDataReady( editor: any, callback?: Function ) {
 	return new Promise( res => {
 		editor.once( 'dataReady', () => {
 			res();
 		}, null, null, 9999 );
+
+		callback && callback();
 	} );
 }

--- a/src/test.tools.ts
+++ b/src/test.tools.ts
@@ -5,3 +5,11 @@ export function whenEvent( evtName: string, component: CKEditorComponent ) {
 		component[ evtName ].subscribe( res );
 	} );
 }
+
+export function whenDataReady( editor: any ) {
+	return new Promise( res => {
+		editor.once( 'dataReady', () => {
+			res();
+		}, null, null, 9999 );
+	} );
+}

--- a/src/test.tools.ts
+++ b/src/test.tools.ts
@@ -18,7 +18,6 @@ export function whenDataReady( editor: any, callback?: Function ) {
 
 export function setDataMultipleTimes( editor: any, data: Array<string> ) {
 	return new Promise( res => {
-		debugger;
 		if ( !editor.editable().isInline() ) {
 			// Due to setData() issue with iframe based editor, subsequent setData() calls
 			// should be performed asynchronously (https://github.com/ckeditor/ckeditor4/issues/3669).

--- a/src/test.tools.ts
+++ b/src/test.tools.ts
@@ -15,3 +15,30 @@ export function whenDataReady( editor: any, callback?: Function ) {
 		callback && callback();
 	} );
 }
+
+export function setDataMultipleTimes( editor: any, data: Array<string> ) {
+	return new Promise( res => {
+		debugger;
+		if ( !editor.editable().isInline() ) {
+			// Due to setData() issue with iframe based editor, subsequent setData() calls
+			// should be performed asynchronously (https://github.com/ckeditor/ckeditor4/issues/3669).
+			setDataHelper( editor, data, res );
+		} else {
+			data.forEach( content => editor.setData( content ) );
+			res();
+		}
+	} );
+}
+
+function setDataHelper( editor: any, data: Array<string>, done: Function ) {
+	if ( data.length ) {
+		const content: string = data.shift();
+
+		setTimeout( () => {
+			editor.setData( content );
+			setDataHelper( editor, data, done );
+		}, 100 );
+	} else {
+		setTimeout( done, 100 );
+	}
+}


### PR DESCRIPTION
## Description

This PR enables usage of `classic` editor. Also it changes default editor type to `classic`. Editor won't be rendered in temporary element outside of component. Now it renders in place where it lives. Tests and samples are updated, few new test cases are added. 

## Notes

- This is based on branch `t/6 so I propose to merge #35 first.
- This update requires CKEditor from branch `t/3115`, so to run tests you need to serve `ckeditor.js` from that branch, and then run `npm run test -- -u http://link/to/served/ckeditor.js`. **Because of this travis build will fail.**
- To test manually you need to add `<script src="http://link/to/served/ckeditor.js"></script>` in `./src/index.html`

Closes #6 
