### PR TITLE
Allow Angular 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ See the [CKEditor 4 Angular Integration](https://ckeditor.com/docs/ckeditor4/lat
 
 The CKEditor 4 Angular component works with all the [supported browsers](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_browsers.html#officially-supported-browsers) except for Internet Explorer 8-10.
 
+## Supported Angular versions
+The integration can be used together with Angular at version 5.0.0 and higher. It is an implication of Angular metadata produced for this package by the Angular builder. Note that the package.json used in the main repository isn't published on NPM (the production one is present in src/ckeditor/package.json), so there are only a few peer dependencies to @angular/core >= 5.0.0, @angular/common >= 5.0.0 and @angular/forms >= 5.0.0 required by this package.
+
 ## Contributing
 
 Here is how you can contribute to the development of the component. Any feedback and help will be most appreciated!

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ See the [CKEditor 4 Angular Integration](https://ckeditor.com/docs/ckeditor4/lat
 The CKEditor 4 Angular component works with all the [supported browsers](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_browsers.html#officially-supported-browsers) except for Internet Explorer 8-10.
 
 ## Supported Angular versions
-The integration can be used together with Angular at version 5.0.0 and higher. It is an implication of Angular metadata produced for this package by the Angular builder. Note that the package.json used in the main repository isn't published on NPM (the production one is present in src/ckeditor/package.json), so there are only a few peer dependencies to @angular/core >= 5.0.0, @angular/common >= 5.0.0 and @angular/forms >= 5.0.0 required by this package.
+
+The integration can be used together with Angular at version 5.0.0 and higher. It is an implication of Angular metadata produced for this package by the Angular builder. Note that the package.json used in the main repository isn't published on NPM (the production one is present in `src/ckeditor/package.json`), so there are only a few peer dependencies to `@angular/core` >= 5.0.0, `@angular/common` >= 5.0.0 and `@angular/forms` >= 5.0.0 required by this package.
 
 ## Contributing
 

--- a/e2e/src/app.e2e-spec.ts
+++ b/e2e/src/app.e2e-spec.ts
@@ -24,7 +24,7 @@ describe( 'workspace-project App', () => {
 		} );
 
 		it( 'should display welcome message', () => {
-			expect( page.getParagraphText() ).toEqual( 'CKEditor integration with Angular 2+' );
+			expect( page.getParagraphText() ).toEqual( 'CKEditor integration with Angular' );
 		} );
 
 		it( 'should display editor with initial content', async () => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ckeditor4-angular",
   "version": "1.0.0",
-  "description": "Official Angular 2+ component for CKEditor 4.",
+  "description": "Official Angular component for CKEditor 4.",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,4 +1,4 @@
-<h1>CKEditor integration with Angular 2+</h1>
+<h1>CKEditor integration with Angular</h1>
 
 <nav>
 	<ul>

--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -191,7 +191,7 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 	 */
 	@Input() editorUrl = 'https://cdn.ckeditor.com/4.12.1/standard-all/ckeditor.js';
 
-	constructor( private elementRef: ElementRef<HTMLElement>, private ngZone: NgZone ) {
+	constructor( private elementRef: ElementRef, private ngZone: NgZone ) {
 	}
 
 	ngAfterViewInit(): void {

--- a/src/ckeditor/package.json
+++ b/src/ckeditor/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "ckeditor4-angular",
 	"version": "0.1.0",
-	"description": "Official Angular 2+ component for CKEditor 4.",
+	"description": "Official Angular component for CKEditor 4.",
 	"keywords": [
 		"wysiwyg",
 		"rich text",


### PR DESCRIPTION
Applied change required to work with Angular 5, see https://github.com/ckeditor/ckeditor4-angular/issues/39#issuecomment-508696810

Also changed all leftover `Angular 2+` references so that version isn't mentioned.

Closes #39. Closes #37. Closes #42.