### PR TITLE
Fix for: Two-way binding does not work when 'undo' plugin is removed

### DIFF
--- a/src/app/demo-form/demo-form.component.spec.ts
+++ b/src/app/demo-form/demo-form.component.spec.ts
@@ -87,10 +87,33 @@ describe( 'DemoFormComponent', () => {
 			resetButton.click();
 
 			fixture.detectChanges();
-
 			expect( component.formDataPreview ).toEqual( '{"name":null,"surname":null,"description":null}' );
 
 			done();
 		} );
 	} );
+
+	[ {
+		config: undefined,
+		msg: 'with undo plugin'
+	}, {
+		config: { removePlugins: 'undo' },
+		msg: 'without undo plugin'
+	}].forEach( ( { config, msg } ) => {
+		describe( msg, () => {
+			beforeEach( () => {
+				ckeditorComponent.config = config;
+				fixture.detectChanges();
+			} );
+			it( 'should emit onChange event', () => {
+				const spy = spyOn( ckeditorComponent, 'onChange' );
+
+				ckeditorComponent.instance.setData( '<p>An unidentified person</p>' );
+				fixture.detectChanges();
+
+				expect( spy ).toHaveBeenCalledTimes( 1 );
+			} );
+		} );
+	} );
+
 } );

--- a/src/ckeditor/ckeditor.component.spec.ts
+++ b/src/ckeditor/ckeditor.component.spec.ts
@@ -159,6 +159,44 @@ describe( 'CKEditorComponent', () => {
 						expect( component.instance.config.width ).toBe( 1000 );
 						expect( component.instance.config.height ).toBe( 1000 );
 					} );
+
+					it( 'editor should have undo plugin', () => {
+						expect( component.instance.plugins.undo ).not.toBeUndefined();
+					} );
+
+					it( 'should register changes', () => {
+						const spy = jasmine.createSpy();
+
+						component.registerOnChange( spy );
+						component.instance.setData( '<p>Hello World!</p>' );
+						component.instance.setData( '</p>I am CKEditor for Angular!</p>' );
+
+						expect( spy ).toHaveBeenCalledTimes( 2 );
+					} );
+				} );
+
+				describe( 'when set without undo plugin', () => {
+					beforeEach( ( done ) => {
+						component.config = {
+							removePlugins: 'undo'
+						};
+						fixture.detectChanges();
+						whenEvent( 'ready', component ).then( done );
+					} );
+
+					it( 'editor should not have undo plugin', () => {
+						expect( component.instance.plugins.undo ).toBeUndefined();
+					} );
+
+					it( 'should register changes without undo plugin', () => {
+						const spy = jasmine.createSpy();
+
+						component.registerOnChange( spy );
+						component.instance.setData( '<p>Hello World!</p>' );
+						component.instance.setData( '</p>I am CKEditor for Angular!</p>' );
+
+						expect( spy ).toHaveBeenCalledTimes( 2 );
+					} );
 				} );
 			} );
 

--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -285,9 +285,11 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 			} );
 		} );
 
-		editor.on( 'change', this.addChangeListener, this );
-
-		if ( !this.instance.undoManager ) {
+		if ( this.instance.undoManager ) {
+			editor.on( 'change', this.addChangeListener, this );
+		}
+		// If 'undo' plugin is not loaded, listen to other events instead of 'change' (#54).
+		else {
 			editor.on( 'selectionCheck', this.addChangeListener, this );
 			editor.on( 'dataReady', this.addChangeListener, this );
 		}

--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -122,6 +122,14 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 	@Output() ready = new EventEmitter<CKEditor4.EventInfo>();
 
 	/**
+	 * Fires when the editor data is loaded, e.g. after calling setData()
+	 * https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#method-setData
+	 * editor's method. It corresponds with the `editor#dataReady`
+	 * https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#event-dataReady event.
+	 */
+	@Output() dataReady = new EventEmitter<CKEditor4.EventInfo>();
+
+	/**
 	 * Fires when the content of the editor has changed. It corresponds with the `editor#change`
 	 * https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#event-change
 	 * event. For performance reasons this event may be called even when data didn't really changed.
@@ -299,7 +307,13 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 		this.ngZone.run( () => {
 			const newData = this.instance.getData();
 
-			event.name == 'change' ? this.change.emit( event ) : this.selectionCheck.emit( event );
+			if ( event.name == 'change' ) {
+				this.change.emit( event );
+			} else if ( event.name == 'selectionCheck' ) {
+				this.selectionCheck.emit( event );
+			} else if ( event.name == 'dataReady' ) {
+				this.dataReady.emit( event );
+			}
 
 			if ( newData === this.data ) {
 				return;

--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -133,6 +133,8 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 	 * Fires when the content of the editor has changed. It corresponds with the `editor#change`
 	 * https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#event-change
 	 * event. For performance reasons this event may be called even when data didn't really changed.
+	 * Please note that this event will only be fired when `undo` plugin is loaded. If you need to
+	 * listen for editor changes (e.g. for two-way data binding), use `dataChange` event instead.
 	 */
 	@Output() change = new EventEmitter<CKEditor4.EventInfo>();
 

--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -286,16 +286,16 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 		} );
 
 		if ( this.instance.undoManager ) {
-			editor.on( 'change', this.addChangeListener, this );
+			editor.on( 'change', this.propagateChange, this );
 		}
 		// If 'undo' plugin is not loaded, listen to other events instead of 'change' (#54).
 		else {
-			editor.on( 'selectionCheck', this.addChangeListener, this );
-			editor.on( 'dataReady', this.addChangeListener, this );
+			editor.on( 'selectionCheck', this.propagateChange, this );
+			editor.on( 'dataReady', this.propagateChange, this );
 		}
 	}
 
-	private addChangeListener( event: any ): void {
+	private propagateChange( event: any ): void {
 		this.ngZone.run( () => {
 			const newData = this.instance.getData();
 

--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -257,7 +257,7 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 				// Locking undoManager prevents 'change' event.
 				// Trigger it manually to updated bound data.
 				if ( this.data !== instance.getData() ) {
-					instance.fire( 'change' );
+					undo ? instance.fire( 'change' ) : instance.fire( 'dataReady' );
 				}
 				undo && undo.unlock();
 			}

--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -293,13 +293,14 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 			} );
 		} );
 
+		editor.on( 'dataReady', this.propagateChange, this );
+
 		if ( this.instance.undoManager ) {
 			editor.on( 'change', this.propagateChange, this );
 		}
-		// If 'undo' plugin is not loaded, listen to other events instead of 'change' (#54).
+		// If 'undo' plugin is not loaded, listen to 'selectionCheck' event instead. (#54).
 		else {
 			editor.on( 'selectionCheck', this.propagateChange, this );
-			editor.on( 'dataReady', this.propagateChange, this );
 		}
 	}
 

--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -289,6 +289,7 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 
 		if ( !this.instance.undoManager ) {
 			editor.on( 'selectionCheck', this.addChangeListener, this );
+			editor.on( 'dataReady', this.addChangeListener, this );
 		}
 	}
 

--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -139,12 +139,6 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 	@Output() change = new EventEmitter<CKEditor4.EventInfo>();
 
 	/**
-	 * Used as a replacement if 'undo' plugin is not loaded. Fires when the selection inside editor has changed.
-	 * It corresponds with the `editor#selectionCheck` event. This event may be called when data in editor didn't change.
-	 */
-	@Output() selectionCheck = new EventEmitter<CKEditor4.EventInfo>();
-
-	/**
 	 * Fires when the content of the editor has changed. In contrast to `change` and `selectionCheck` - only emits when
 	 * data really changed thus can be successfully used with `[data]` and two way `[(data)]` binding.
 	 *
@@ -312,8 +306,6 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 
 			if ( event.name == 'change' ) {
 				this.change.emit( event );
-			} else if ( event.name == 'selectionCheck' ) {
-				this.selectionCheck.emit( event );
 			} else if ( event.name == 'dataReady' ) {
 				this.dataReady.emit( event );
 			}

--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -139,7 +139,7 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 	@Output() change = new EventEmitter<CKEditor4.EventInfo>();
 
 	/**
-	 * Fires when the content of the editor has changed. In contrast to `change` and `selectionCheck` - only emits when
+	 * Fires when the content of the editor has changed. In contrast to `change` - only emits when
 	 * data really changed thus can be successfully used with `[data]` and two way `[(data)]` binding.
 	 *
 	 * See more: https://angular.io/guide/template-syntax#two-way-binding---


### PR DESCRIPTION
If `undo` plugin is not loaded, editor doesn't produce [`change`](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_angular.html#change) event (it's upstream from CKEditor4 - [ckeditor/ckeditor4#2384](https://github.com/ckeditor/ckeditor4/issues/2384)), which in turn means that integration-specific [`dataChange`](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_angular.html#datachange) event doesn't appear neither. For that reason two-way data binding didn't work without `undo`.

This PR introduces listeners for `selectionCheck` (for general use) and `dataReady` (needed for  [setData()](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#method-setData) method and switching between WYSIWYG and source mode) as a replacement, when `undo` plugin is not loaded. 

Closes #54.