### PR TITLE
Fix paste and afterPaste tests on IE11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@
 npm-debug.log
 yarn-error.log
 testem.log
+local.log
 /typings
 
 # System Files

--- a/src/ckeditor/ckeditor.component.spec.ts
+++ b/src/ckeditor/ckeditor.component.spec.ts
@@ -382,21 +382,24 @@ describe( 'CKEditorComponent', () => {
 					} );
 
 					it( 'paste should emit component paste', () => {
-						const pasteEventMock = mockPasteEvent();
-						pasteEventMock.$.clipboardData.setData( 'text/html', '<p>bam</p>' );
-
 						fixture.detectChanges();
 
 						const spy = jasmine.createSpy();
 						component.paste.subscribe( spy );
 
 						const editable = component.instance.editable();
-						editable.fire( 'paste', pasteEventMock );
+						const editor = editable.getEditor( false );
 
-						return whenEvent( 'paste', component ).then( () => {
+						const eventPromise =  whenEvent( 'paste', component ).then( () => {
 							expect( spy ).toHaveBeenCalledTimes( 1 );
 							expect( component.instance.getData() ).toEqual( '<p>bam</p>\n' );
 						} );
+
+						editor.fire( 'paste', {
+							dataValue: '<p>bam</p>'
+						} );
+
+						return eventPromise;
 					} );
 
 					it( 'afterPaste should emit component afterPaste', () => {

--- a/src/ckeditor/ckeditor.component.spec.ts
+++ b/src/ckeditor/ckeditor.component.spec.ts
@@ -400,21 +400,24 @@ describe( 'CKEditorComponent', () => {
 					} );
 
 					it( 'afterPaste should emit component afterPaste', () => {
-						const pasteEventMock = mockPasteEvent();
-						pasteEventMock.$.clipboardData.setData( 'text/html', '<p>bam</p>' );
-
 						fixture.detectChanges();
 
 						const spy = jasmine.createSpy();
 						component.afterPaste.subscribe( spy );
 
 						const editable = component.instance.editable();
-						editable.fire( 'paste', pasteEventMock );
+						const editor = editable.getEditor( false );
 
-						return whenEvent( 'afterPaste', component ).then( () => {
+						const eventPromise = whenEvent( 'afterPaste', component ).then( () => {
 							expect( spy ).toHaveBeenCalledTimes( 1 );
 							expect( component.instance.getData() ).toEqual( '<p>bam</p>\n' );
 						} );
+
+						editor.fire( 'paste', {
+							dataValue: '<p>bam</p>'
+						} );
+
+						return eventPromise;
 					} );
 
 					it( 'drag/drop events should emit component dragStart, dragEnd and drop', async done => {


### PR DESCRIPTION
Fixes paste and afterPaste tests on IE11 by not setting clipboard data.

Closes #104