### PR TITLE
Improve stability of package and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Other Changes:
 
 * [#98](https://github.com/ckeditor/ckeditor4-angular/issues/98): Updated repository dependencies (no changes in the actual `ckeditor4-angular` package).
+* [#128](https://github.com/ckeditor/ckeditor4-angular/issues/128): Improve the stability of `getEditorNamespace()` method.
 
 ## ckeditor4-angular 1.2.2
 

--- a/src/app/demo-form/demo-form.component.css
+++ b/src/app/demo-form/demo-form.component.css
@@ -27,7 +27,7 @@ form > div {
 
 pre {
 	word-wrap: break-word;
-    white-space: pre-wrap;
+	white-space: pre-wrap;
 }
 
 p.alert {

--- a/src/app/demo-form/demo-form.component.html
+++ b/src/app/demo-form/demo-form.component.html
@@ -18,7 +18,7 @@
 		[(ngModel)]="model.description"
 		id="description"
 		name="description"
-  		type="divarea">
+		type="divarea">
 	</ckeditor>
 
 	<p *ngIf="description && description.dirty" class="alert">Description is "dirty".</p>

--- a/src/ckeditor/ckeditor.component.spec.ts
+++ b/src/ckeditor/ckeditor.component.spec.ts
@@ -4,12 +4,11 @@
  */
 
 import waitUntil from 'wait-until-promise';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CKEditorComponent } from './ckeditor.component';
 import {
 	fireDragEvent,
 	mockDropEvent,
-	mockPasteEvent,
 	setDataMultipleTimes,
 	whenDataReady,
 	whenEvent
@@ -24,11 +23,11 @@ describe( 'CKEditorComponent', () => {
 		fixture: ComponentFixture<CKEditorComponent>,
 		config: Object;
 
-	beforeEach( async( () => {
-		TestBed.configureTestingModule( {
+	beforeEach( () => {
+		return TestBed.configureTestingModule( {
 			declarations: [ CKEditorComponent ]
 		} ).compileComponents();
-	} ) );
+	} )
 
 	beforeEach( () => {
 		fixture = TestBed.createComponent( CKEditorComponent );
@@ -73,9 +72,10 @@ describe( 'CKEditorComponent', () => {
 				} );
 
 				it( 'should have proper editor type', () => {
-					whenEvent( 'ready', component ).then( () => {
+					return whenEvent( 'ready', component ).then( () => {
 						fixture.detectChanges();
-						expect( component.instance.editable().isInline() ).toBe( component.type !== EditorType.CLASSIC );
+						expect( component.instance.editable().isInline() )
+							.toBe( component.type !== EditorType.CLASSIC );
 					} );
 				} );
 
@@ -170,14 +170,15 @@ describe( 'CKEditorComponent', () => {
 				} );
 
 				describe( 'when set with config', () => {
-					beforeEach( done => {
+					beforeEach( () => {
 						component.config = {
 							readOnly: true,
 							width: 1000,
 							height: 1000
 						};
 						fixture.detectChanges();
-						whenEvent( 'ready', component ).then( done );
+
+						return whenEvent( 'ready', component );
 					} );
 
 					it( 'editor should be readOnly', () => {
@@ -193,84 +194,80 @@ describe( 'CKEditorComponent', () => {
 						expect( component.instance.plugins.undo ).not.toBeUndefined();
 					} );
 
-					it( 'should register changes', async done => {
+					it( 'should register changes', () => {
 						const spy = jasmine.createSpy();
 
 						component.registerOnChange( spy );
 
-						setDataMultipleTimes( component.instance, [
+						return setDataMultipleTimes( component.instance, [
 							'<p>Hello World!</p>',
 							'<p>I am CKEditor for Angular!</p>'
 						] ).then( () => {
 							expect( spy ).toHaveBeenCalledTimes( 2 );
-
-							done();
 						} );
 					} );
 				} );
 
 				describe( 'when set without undo plugin', () => {
-					beforeEach( ( done ) => {
+					beforeEach( () => {
 						component.config = {
 							removePlugins: 'undo'
 						};
 						fixture.detectChanges();
-						whenEvent( 'ready', component ).then( done );
+						return whenEvent( 'ready', component );
 					} );
 
 					it( 'editor should not have undo plugin', () => {
 						expect( component.instance.plugins.undo ).toBeUndefined();
 					} );
 
-					it( 'should register changes without undo plugin', async done => {
+					it( 'should register changes without undo plugin', () => {
 						const spy = jasmine.createSpy();
 
 						component.registerOnChange( spy );
 
-						setDataMultipleTimes( component.instance, [
+						return setDataMultipleTimes( component.instance, [
 							'<p>Hello World!</p>',
 							'<p>I am CKEditor for Angular!</p>'
 						] ).then( () => {
 							expect( spy ).toHaveBeenCalledTimes( 2 );
-
-							done();
 						} );
 					} );
 				} );
 			} );
 
 			describe( 'on destroy', () => {
-				it ( 'should not have call runOutsideAngular when destroy before DOM loaded', done => {
+				it ( 'should not have call runOutsideAngular when destroy before DOM loaded', () => {
 					spyOn( fixture.ngZone, 'runOutsideAngular' );
 
 					fixture.detectChanges();
 
-					waitUntil( () => {
+					return waitUntil( () => {
 						fixture.destroy();
 						return true;
 					}, 0 ).then( () => {
 						expect( fixture.ngZone.runOutsideAngular ).toHaveBeenCalledTimes( 1 );
-					} ).then( done );
+					} );
 				} );
 
-				it ( 'should not have call runOutsideAngular when destroy before DOM loaded', done => {
+				it ( 'should not have call runOutsideAngular when destroy before DOM loaded', () => {
 					spyOn( fixture.ngZone, 'runOutsideAngular' );
 
 					fixture.detectChanges();
 
-					waitUntil( () => {
+					return waitUntil( () => {
 						fixture.destroy();
 						return true;
 					}, 200 ).then( () => {
 						expect( fixture.ngZone.runOutsideAngular ).toHaveBeenCalledTimes( 1 );
-					} ).then( done );
+					} );
 				} );
 			} );
 
 			describe( 'when component is ready', () => {
-				beforeEach( done => {
+				beforeEach( () => {
 					fixture.detectChanges();
-					whenEvent( 'ready', component ).then( done );
+					return whenEvent( 'ready', component );
 				} );
 
 				it( 'should be initialized', () => {
@@ -319,18 +316,16 @@ describe( 'CKEditorComponent', () => {
 					const data = '<b>foo</b>',
 						expected = '<p><strong>foo</strong></p>\n';
 
-					it( 'should be configurable at the start of the component', async done => {
+					it( 'should be configurable at the start of the component', async () => {
 						fixture.detectChanges();
 
 						await whenDataReady( component.instance, () => component.data = data );
 
 						expect( component.data ).toEqual( expected );
 						expect( component.instance.getData() ).toEqual( expected );
-
-						done();
 					} );
 
-					it( 'should be writeable by ControlValueAccessor', async done => {
+					it( 'should be writeable by ControlValueAccessor', async () => {
 						fixture.detectChanges();
 
 						const editor = component.instance;
@@ -342,8 +337,6 @@ describe( 'CKEditorComponent', () => {
 						await whenDataReady( editor, () => component.writeValue( '<p><i>baz</i></p>' ) );
 
 						expect( component.instance.getData() ).toEqual( '<p><em>baz</em></p>\n' );
-
-						done();
 					} );
 				} );
 
@@ -423,7 +416,7 @@ describe( 'CKEditorComponent', () => {
 						return eventPromise;
 					} );
 
-					it( 'drag/drop events should emit component dragStart, dragEnd and drop', async done => {
+					it( 'drag/drop events should emit component dragStart, dragEnd and drop', done => {
 						fixture.detectChanges();
 
 						const spyDragStart = jasmine.createSpy( 'dragstart' );
@@ -517,17 +510,16 @@ describe( 'CKEditorComponent', () => {
 						expect( spy ).toHaveBeenCalled();
 					} );
 
-					it( 'onChange callback should be called when editor model changes', async done => {
+					it( 'onChange callback should be called when editor model changes', () => {
 						fixture.detectChanges();
 
 						const spy = jasmine.createSpy();
 						component.registerOnChange( spy );
 
-						setDataMultipleTimes( component.instance, [
+						return setDataMultipleTimes( component.instance, [
 							'initial', 'initial', 'modified'
 						] ).then( () => {
 							expect( spy ).toHaveBeenCalledTimes( 2 );
-							done();
 						} );
 					} );
 				} );

--- a/src/ckeditor/ckeditor.component.spec.ts
+++ b/src/ckeditor/ckeditor.component.spec.ts
@@ -141,7 +141,7 @@ describe( 'CKEditorComponent', () => {
 					warn: isDivarea
 				} ].forEach( ( { newConfig, msg, warn } ) => {
 					describe( msg, () => {
-						beforeAll( () => {
+						beforeEach( () => {
 							config = newConfig;
 						} );
 

--- a/src/ckeditor/ckeditor.component.spec.ts
+++ b/src/ckeditor/ckeditor.component.spec.ts
@@ -416,7 +416,7 @@ describe( 'CKEditorComponent', () => {
 						return eventPromise;
 					} );
 
-					it( 'drag/drop events should emit component dragStart, dragEnd and drop', done => {
+					it( 'drag/drop events should emit component dragStart, dragEnd and drop', () => {
 						fixture.detectChanges();
 
 						const spyDragStart = jasmine.createSpy( 'dragstart' );
@@ -428,30 +428,26 @@ describe( 'CKEditorComponent', () => {
 						const spyDrop = jasmine.createSpy( 'drop' );
 						component.drop.subscribe( spyDrop );
 
-						whenDataReady( component.instance, () => {
-							const dropEvent = mockDropEvent();
-							const paragraph = component.instance.editable().findOne( 'p' );
+						const dropEvent = mockDropEvent();
+						const paragraph = component.instance.editable().findOne( 'p' );
 
-							component.instance.getSelection().selectElement( paragraph );
+						component.instance.getSelection().selectElement( paragraph );
 
-							fireDragEvent( 'dragstart', component.instance, dropEvent );
+						fireDragEvent( 'dragstart', component.instance, dropEvent );
 
-							expect( spyDragStart ).toHaveBeenCalledTimes( 1 );
+						expect( spyDragStart ).toHaveBeenCalledTimes( 1 );
 
-							fireDragEvent( 'dragend', component.instance, dropEvent );
+						fireDragEvent( 'dragend', component.instance, dropEvent );
 
-							expect( spyDragEnd ).toHaveBeenCalledTimes( 1 );
+						expect( spyDragEnd ).toHaveBeenCalledTimes( 1 );
 
-							// There is some issue in Firefox with simulating drag-drop flow. The drop event
-							// is not fired making this assertion fail. Let's skip it for now.
-							if ( !CKEDITOR.env.gecko ) {
-								fireDragEvent( 'drop', component.instance, dropEvent );
+						// There is some issue in Firefox with simulating drag-drop flow. The drop event
+						// is not fired making this assertion fail. Let's skip it for now.
+						if ( !CKEDITOR.env.gecko ) {
+							fireDragEvent( 'drop', component.instance, dropEvent );
 
-								expect( spyDrop ).toHaveBeenCalledTimes( 1 );
-							}
-
-							done();
-						} );
+							expect( spyDrop ).toHaveBeenCalledTimes( 1 );
+						}
 					} );
 
 					it( 'fileUploadRequest should emit component fileUploadRequest', () => {

--- a/src/ckeditor/ckeditor.component.spec.ts
+++ b/src/ckeditor/ckeditor.component.spec.ts
@@ -383,7 +383,7 @@ describe( 'CKEditorComponent', () => {
 						const editable = component.instance.editable();
 						const editor = editable.getEditor( false );
 
-						const eventPromise =  whenEvent( 'paste', component ).then( () => {
+						const eventPromise = whenEvent( 'paste', component ).then( () => {
 							expect( spy ).toHaveBeenCalledTimes( 1 );
 							expect( component.instance.getData() ).toEqual( '<p>bam</p>\n' );
 						} );

--- a/src/ckeditor/ckeditor.helpers.spec.ts
+++ b/src/ckeditor/ckeditor.helpers.spec.ts
@@ -49,8 +49,8 @@ describe( 'getEditorNamespace', () => {
 	} );
 
 	it( 'returns the same promise', () => {
-		const promise1 =  getEditorNamespace( fakeScript );
-		const promise2 =  getEditorNamespace( fakeScript );
+		const promise1 = getEditorNamespace( fakeScript );
+		const promise2 = getEditorNamespace( fakeScript );
 
 		expect( promise1 ).toBe( promise2 );
 

--- a/src/ckeditor/ckeditor.helpers.spec.ts
+++ b/src/ckeditor/ckeditor.helpers.spec.ts
@@ -21,9 +21,10 @@ describe( 'getEditorNamespace', () => {
 	} );
 
 	it( 'typeError thrown when empty string passed', () => {
-		expect( () => {
-			getEditorNamespace( '' );
-		} ).toThrowError( 'CKEditor URL must be a non-empty string.' );
+		return getEditorNamespace( '' ).catch( err => {
+			expect( err instanceof Error );
+			expect( err.message ).toEqual( 'CKEditor URL must be a non-empty string.' );
+		} );
 	} );
 
 	it( 'returns promise even if namespace is present', () => {
@@ -52,6 +53,11 @@ describe( 'getEditorNamespace', () => {
 	} );
 
 	it( 'returns the same promise', () => {
-		expect( getEditorNamespace( fakeScript ) ).toBe( getEditorNamespace( fakeScript ) );
+		const promise1 =  getEditorNamespace( fakeScript );
+		const promise2 =  getEditorNamespace( fakeScript );
+
+		expect( promise1 ).toBe( promise2 );
+
+		return Promise.all( [ promise1, promise2 ] )
 	} );
 } );

--- a/src/ckeditor/ckeditor.helpers.spec.ts
+++ b/src/ckeditor/ckeditor.helpers.spec.ts
@@ -9,8 +9,6 @@ declare let CKEDITOR: any;
 
 describe( 'getEditorNamespace', () => {
 	const fakeScript = 'data:text/javascript;base64,d2luZG93LkNLRURJVE9SID0ge307';
-	let isIe10 = navigator.userAgent.toLowerCase().indexOf( 'trident/' ) > -1;
-	isIe10 = isIe10 && document[ 'documentMode' ] === 10;
 
 	beforeEach( () => {
 		delete window[ 'CKEDITOR' ];
@@ -38,13 +36,11 @@ describe( 'getEditorNamespace', () => {
 		} );
 	} );
 
-	if ( !isIe10 ) { // Ignore unstable test on IE10.
-		it( 'load script and resolves with loaded namespace', () => {
-			return getEditorNamespace( fakeScript ).then( namespace => {
-				expect( namespace ).toBe( CKEDITOR );
-			} );
+	it( 'load script and resolves with loaded namespace', () => {
+		return getEditorNamespace( fakeScript ).then( namespace => {
+			expect( namespace ).toBe( CKEDITOR );
 		} );
-	}
+	} );
 
 	it( 'rejects with error when script cannot be loaded', () => {
 		return getEditorNamespace( 'non-existent.js' ).catch( err => {

--- a/src/ckeditor/ckeditor.helpers.ts
+++ b/src/ckeditor/ckeditor.helpers.ts
@@ -10,7 +10,7 @@ let promise;
 
 export function getEditorNamespace( editorURL: string ): Promise<{ [ key: string ]: any; }> {
 	if ( editorURL.length < 1 ) {
-		throw new TypeError( 'CKEditor URL must be a non-empty string.' );
+		return Promise.reject( new TypeError( 'CKEditor URL must be a non-empty string.' ) );
 	}
 
 	if ( 'CKEDITOR' in window ) {
@@ -22,8 +22,9 @@ export function getEditorNamespace( editorURL: string ): Promise<{ [ key: string
 					scriptReject( err );
 				} else {
 					scriptResolve( CKEDITOR );
-					promise = undefined;
 				}
+
+				promise = undefined;
 			} );
 		} );
 	}

--- a/src/karma.conf.js
+++ b/src/karma.conf.js
@@ -13,7 +13,7 @@ module.exports = function ( config ) {
 			clearContext: false, // leave Jasmine Spec Runner output visible in browser
 			captureConsole: false,
 			jasmine: {
-				random: true
+				random: false
 			}
 		},
 		coverageIstanbulReporter: {

--- a/src/karma.conf.js
+++ b/src/karma.conf.js
@@ -13,7 +13,7 @@ module.exports = function ( config ) {
 			clearContext: false, // leave Jasmine Spec Runner output visible in browser
 			captureConsole: false,
 			jasmine: {
-				random: false
+				random: true
 			}
 		},
 		coverageIstanbulReporter: {

--- a/src/test.tools.ts
+++ b/src/test.tools.ts
@@ -31,25 +31,6 @@ export function setDataMultipleTimes( editor: any, data: Array<string> ) {
 	} );
 }
 
-export function mockPasteEvent() {
-	const dataTransfer = mockNativeDataTransfer();
-	let target = new CKEDITOR.dom.element( 'div' );
-
-	return {
-		$: {
-			ctrlKey: true,
-			clipboardData: ( CKEDITOR.env.ie && CKEDITOR.env.version < 16 ) ? undefined : dataTransfer
-		},
-		preventDefault: function() {},
-		getTarget: function() {
-			return target;
-		},
-		setTarget: function( t: any ) {
-			target = t;
-		}
-	};
-}
-
 export function mockDropEvent() {
 	const dataTransfer = mockNativeDataTransfer();
 	let target = new CKEDITOR.dom.element( 'div' );


### PR DESCRIPTION
I've fixed some tests so the whole test suite is more stable now. Also, I've corrected the implementation of `getEditorNamespace` because:

* in case of error, it didn't clean up the promise
* in case of empty string, it directly threw an error, which is not consistent with promise-based functions (you shouldn't have to decorate promised function with try/catch block)

The tests are still failing because of https://github.com/ckeditor/ckeditor4-angular/blob/dc423da5ecc473a834dd6b31fd6b53918f30fe37/src/ckeditor/ckeditor.component.spec.ts#L122-L170 test suite. However, those tests should no longer validate this case, as we already fixed upstream CKEditor 4 issue which required using `divarea` plugin for integrations. I will extract the issue as a separate ticket, as we should clean up the production code also.

## Proposed changelog entry

```
* [#128](https://github.com/ckeditor/ckeditor4-angular/issues/128): Improve the stability of `getEditorNamespace()` method.
```

Closes #121
Closes #129. 
Closes #128.