### PR TITLE
Clean up editor types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CKEditor 4 Angular Integration Changelog
 
+## ckeditor-angular 2.0.0
+
+API Changes:
+
+* [#130](https://github.com/ckeditor/ckeditor4-angular/issues/130): `DIVAREA` editor type has been deprecated. Use [`divarea` plugin](https://ckeditor.com/cke4/addon/divarea) instead.
+
 ## ckeditor4-angular 1.3.0
 
 Other Changes:

--- a/src/app/demo-form/demo-form.component.html
+++ b/src/app/demo-form/demo-form.component.html
@@ -17,8 +17,7 @@
 	<ckeditor
 		[(ngModel)]="model.description"
 		id="description"
-		name="description"
-		type="divarea">
+		name="description">
 	</ckeditor>
 
 	<p *ngIf="description && description.dirty" class="alert">Description is "dirty".</p>

--- a/src/app/demo-form/demo-form.component.html
+++ b/src/app/demo-form/demo-form.component.html
@@ -17,7 +17,8 @@
 	<ckeditor
 		[(ngModel)]="model.description"
 		id="description"
-		name="description">
+		name="description"
+		[config]="{ extraPlugins: 'divarea' }">
 	</ckeditor>
 
 	<p *ngIf="description && description.dirty" class="alert">Description is "dirty".</p>

--- a/src/app/demo-form/demo-form.component.spec.ts
+++ b/src/app/demo-form/demo-form.component.spec.ts
@@ -87,7 +87,6 @@ describe( 'DemoFormComponent', () => {
 		} );
 
 		ckeditorComponent.instance.setData( '<p>An unidentified person</p>' );
-
 	} );
 
 	it( 'when reset button is clicked should reset form', done => {

--- a/src/app/simple-usage/simple-usage.component.html
+++ b/src/app/simple-usage/simple-usage.component.html
@@ -10,6 +10,7 @@
 		[readOnly]="isReadOnly"
 		[hidden]="isHidden"
 		type="{{ editor | lowercase }}"
+		[config]="{ extraPlugins: 'divarea' }"
 
 		(ready)="onReady( $event, editor )"
 		(change)="onChange( $event, editor )"

--- a/src/app/simple-usage/simple-usage.component.spec.ts
+++ b/src/app/simple-usage/simple-usage.component.spec.ts
@@ -110,7 +110,6 @@ describe( 'SimpleUsageComponent', () => {
 		} );
 	} );
 
-
 	describe( 'listeners', () => {
 		beforeEach( () => {
 			spy = spyOn( console, 'log' );

--- a/src/app/simple-usage/simple-usage.component.ts
+++ b/src/app/simple-usage/simple-usage.component.ts
@@ -19,7 +19,7 @@ export class SimpleUsageComponent {
 While it’s also nice to learn about cultures online or from books, nothing comes close to experiencing cultural diversity in person.
 You learn to appreciate each and every single one of the differences while you become more culturally fluid.</p>`;
 
-	editors = [ 'Classic', 'Divarea', 'Inline' ];
+	editors = [ 'Classic', 'Inline' ];
 
 	isHidden = false;
 

--- a/src/ckeditor/ckeditor.component.spec.ts
+++ b/src/ckeditor/ckeditor.component.spec.ts
@@ -142,6 +142,7 @@ describe( 'CKEditorComponent', () => {
 				} ].forEach( ( { newConfig, msg, warn } ) => {
 					describe( msg, () => {
 						beforeEach( () => {
+						beforeAll( () => {
 							config = newConfig;
 						} );
 

--- a/src/ckeditor/ckeditor.component.spec.ts
+++ b/src/ckeditor/ckeditor.component.spec.ts
@@ -43,7 +43,6 @@ describe( 'CKEditorComponent', () => {
 	} );
 
 	[
-		EditorType.DIVAREA,
 		EditorType.INLINE,
 		EditorType.CLASSIC
 	].forEach( editorType => {
@@ -114,78 +113,6 @@ describe( 'CKEditorComponent', () => {
 							const expectedElement = CKEDITOR.env.ie && method !== 'inline' ? 'SPAN' : 'DIV';
 							expect( fixture.nativeElement.lastChild.tagName ).toEqual( expectedElement );
 						} );
-					} );
-				} );
-
-				const isDivarea = editorType === EditorType.DIVAREA;
-				const isInline = editorType === EditorType.INLINE;
-
-				[ {
-					newConfig: undefined,
-					msg: 'without config',
-					warn: false
-				}, {
-					newConfig: { extraPlugins: 'basicstyles,divarea,link' },
-					msg: 'config.extraPlugins defined as a string',
-					warn: false
-				}, {
-					newConfig: { extraPlugins: [ 'basicstyles', 'divarea', 'link' ] },
-					msg: 'config.extraPlugins defined as an array',
-					warn: false
-				}, {
-					newConfig: { removePlugins: 'basicstyles,divarea,link' },
-					msg: 'config.removePlugins defined as a string',
-					warn: isDivarea
-				}, {
-					newConfig: { removePlugins: [ 'basicstyles', 'divarea', 'link' ] },
-					msg: 'config.removePlugins defined as an array',
-					warn: isDivarea
-				}, {
-					newConfig: { removePlugins: 'basicstyles,floatingspace,link' },
-					msg: 'config.removePlugins defined as a string',
-					warn: isInline
-				}, {
-					newConfig: { removePlugins: [ 'basicstyles', 'floatingspace', 'link' ] },
-					msg: 'config.removePlugins defined as an array',
-					warn: isInline
-				}, ].forEach( ( { newConfig, msg, warn } ) => {
-					describe( msg, () => {
-						beforeAll( () => {
-							config = newConfig;
-						} );
-
-						it( `console ${warn ? 'should' : 'shouldn\'t'} warn`, () => {
-							const spy = spyOn( console, 'warn' );
-
-							fixture.detectChanges();
-
-							return whenEvent( 'ready', component ).then( () => {
-								warn
-									? expect( spy ).toHaveBeenCalled()
-									: expect( spy ).not.toHaveBeenCalled();
-							} );
-						} );
-
-						it( `editor ${ isDivarea ? 'should' : 'shouldn\'t' } use divarea plugin`, () => {
-							fixture.detectChanges();
-
-							return whenEvent( 'ready', component ).then( ( { editor } ) => {
-								isDivarea
-									? expect( editor.plugins.divarea ).not.toBeUndefined()
-									: expect( editor.plugins.divarea ).toBeUndefined();
-							} );
-						} );
-
-						if ( isInline ) {
-							it( `editor should include floatingspace plugin`, () => {
-								fixture.detectChanges();
-
-								return whenEvent( 'ready', component ).then( ( { editor } ) => {
-									console.log(editor.plugins);
-									expect( editor.plugins.floatingspace ).not.toBeUndefined()
-								} );
-							} );
-						}
 					} );
 				} );
 

--- a/src/ckeditor/ckeditor.component.spec.ts
+++ b/src/ckeditor/ckeditor.component.spec.ts
@@ -118,6 +118,7 @@ describe( 'CKEditorComponent', () => {
 				} );
 
 				const isDivarea = editorType === EditorType.DIVAREA;
+				const isInline = editorType === EditorType.INLINE;
 
 				[ {
 					newConfig: undefined,
@@ -132,16 +133,23 @@ describe( 'CKEditorComponent', () => {
 					msg: 'config.extraPlugins defined as an array',
 					warn: false
 				}, {
-					newConfig: { removePlugins: 'basicstyles,divarea,link,divarea' },
+					newConfig: { removePlugins: 'basicstyles,divarea,link' },
 					msg: 'config.removePlugins defined as a string',
 					warn: isDivarea
 				}, {
-					newConfig: { removePlugins: [ 'basicstyles', 'divarea', 'link', 'divarea' ] },
+					newConfig: { removePlugins: [ 'basicstyles', 'divarea', 'link' ] },
 					msg: 'config.removePlugins defined as an array',
 					warn: isDivarea
-				} ].forEach( ( { newConfig, msg, warn } ) => {
+				}, {
+					newConfig: { removePlugins: 'basicstyles,floatingspace,link' },
+					msg: 'config.removePlugins defined as a string',
+					warn: isInline
+				}, {
+					newConfig: { removePlugins: [ 'basicstyles', 'floatingspace', 'link' ] },
+					msg: 'config.removePlugins defined as an array',
+					warn: isInline
+				}, ].forEach( ( { newConfig, msg, warn } ) => {
 					describe( msg, () => {
-						beforeEach( () => {
 						beforeAll( () => {
 							config = newConfig;
 						} );
@@ -167,6 +175,17 @@ describe( 'CKEditorComponent', () => {
 									: expect( editor.plugins.divarea ).toBeUndefined();
 							} );
 						} );
+
+						if ( isInline ) {
+							it( `editor should include floatingspace plugin`, () => {
+								fixture.detectChanges();
+
+								return whenEvent( 'ready', component ).then( ( { editor } ) => {
+									console.log(editor.plugins);
+									expect( editor.plugins.floatingspace ).not.toBeUndefined()
+								} );
+							} );
+						}
 					} );
 				} );
 

--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -291,7 +291,11 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 		this.elementRef.nativeElement.appendChild( element );
 
 		if ( this.type === CKEditor4.EditorType.DIVAREA ) {
-			this.config = this.ensureDivareaPlugin( this.config || {} );
+			this.config = this.ensurePlugin( this.config || {}, 'divarea' );
+		}
+
+		if ( this.type === CKEditor4.EditorType.INLINE ) {
+			this.config = this.ensurePlugin( this.config || {}, 'floatingspace' );
 		}
 
 		const instance: CKEditor4.Editor = this.type === CKEditor4.EditorType.INLINE
@@ -424,17 +428,16 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 		} );
 	}
 
-	private ensureDivareaPlugin( config: CKEditor4.Config ): CKEditor4.Config {
+	private ensurePlugin( config: CKEditor4.Config, pluginName: string ): CKEditor4.Config {
 		let { extraPlugins, removePlugins } = config;
 
-		extraPlugins = this.removePlugin( extraPlugins, 'divarea' ) || '';
-		extraPlugins = extraPlugins.concat( typeof extraPlugins === 'string' ? ',divarea' : 'divarea' );
+		extraPlugins = this.removePlugin( extraPlugins, pluginName ) || '';
+		extraPlugins = extraPlugins.concat( typeof extraPlugins === 'string' ? ( ',' + pluginName ) : pluginName );
 
-		if ( removePlugins && removePlugins.includes( 'divarea' ) ) {
+		if ( removePlugins && removePlugins.includes( pluginName ) ) {
+			removePlugins = this.removePlugin( removePlugins, pluginName );
 
-			removePlugins = this.removePlugin( removePlugins, 'divarea' );
-
-			console.warn( '[CKEDITOR] divarea plugin is required to initialize editor using Angular integration.' );
+			console.warn( '[CKEDITOR] `' + pluginName + '` plugin is required to initialize ' + this.type + ' editor. It was automatically added to the build.' );
 		}
 
 		return Object.assign( {}, config, { extraPlugins, removePlugins } );

--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -291,11 +291,13 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 		this.elementRef.nativeElement.appendChild( element );
 
 		if ( this.type === CKEditor4.EditorType.DIVAREA ) {
-			this.config = this.ensurePlugin( this.config || {}, 'divarea' );
+			this.ensurePlugin( 'divarea' );
+		} else if ( this.config ) {
+			this.config.extraPlugins = this.removePlugin( this.config.extraPlugins, 'divarea' );
 		}
 
 		if ( this.type === CKEditor4.EditorType.INLINE ) {
-			this.config = this.ensurePlugin( this.config || {}, 'floatingspace' );
+			this.ensurePlugin( 'floatingspace' );
 		}
 
 		const instance: CKEditor4.Editor = this.type === CKEditor4.EditorType.INLINE
@@ -428,8 +430,12 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 		} );
 	}
 
-	private ensurePlugin( config: CKEditor4.Config, pluginName: string ): CKEditor4.Config {
-		let { extraPlugins, removePlugins } = config;
+	private ensurePlugin( pluginName: string ) {
+		if ( !this.config ) {
+			this.config = {};
+		}
+
+		let { extraPlugins, removePlugins } = this.config;
 
 		extraPlugins = this.removePlugin( extraPlugins, pluginName ) || '';
 		extraPlugins = extraPlugins.concat( typeof extraPlugins === 'string' ? ( ',' + pluginName ) : pluginName );
@@ -440,7 +446,7 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 			console.warn( '[CKEDITOR] `' + pluginName + '` plugin is required to initialize ' + this.type + ' editor. It was automatically added to the build.' );
 		}
 
-		return Object.assign( {}, config, { extraPlugins, removePlugins } );
+		Object.assign ( this.config, { extraPlugins, removePlugins } );
 	}
 
 	private removePlugin( plugins: string | string[], toRemove: string ): string | string[] {

--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -291,16 +291,6 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 		const element = document.createElement( this.tagName );
 		this.elementRef.nativeElement.appendChild( element );
 
-		if ( this.type === CKEditor4.EditorType.DIVAREA ) {
-			this.ensurePlugin( 'divarea' );
-		} else if ( this.config ) {
-			this.config.extraPlugins = this.removePlugin( this.config.extraPlugins, 'divarea' );
-		}
-
-		if ( this.type === CKEditor4.EditorType.INLINE ) {
-			this.ensurePlugin( 'floatingspace' );
-		}
-
 		const instance: CKEditor4.Editor = this.type === CKEditor4.EditorType.INLINE
 			? CKEDITOR.inline( element, this.config )
 			: CKEDITOR.replace( element, this.config );

--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -421,42 +421,4 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 		} );
 	}
 
-	private ensurePlugin( pluginName: string ) {
-		if ( !this.config ) {
-			this.config = {};
-		}
-
-		let { extraPlugins, removePlugins } = this.config;
-
-		extraPlugins = this.removePlugin( extraPlugins, pluginName ) || '';
-		extraPlugins = extraPlugins.concat( typeof extraPlugins === 'string' ? ( ',' + pluginName ) : pluginName );
-
-		if ( removePlugins && removePlugins.includes( pluginName ) ) {
-			removePlugins = this.removePlugin( removePlugins, pluginName );
-
-			console.warn( '[CKEDITOR] `' + pluginName + '` plugin is required to initialize ' + this.type + ' editor. It was automatically added to the build.' );
-		}
-
-		Object.assign ( this.config, { extraPlugins, removePlugins } );
-	}
-
-	private removePlugin( plugins: string | string[], toRemove: string ): string | string[] {
-		if ( !plugins ) {
-			return null;
-		}
-
-		const isString = typeof plugins === 'string';
-
-		if ( isString ) {
-			plugins = ( plugins as string ).split( ',' );
-		}
-
-		plugins = ( plugins as string[] ).filter( plugin => plugin !== toRemove );
-
-		if ( isString ) {
-			plugins = ( plugins as string[] ).join( ',' );
-		}
-
-		return plugins;
-	}
 }

--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -55,8 +55,8 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 	/**
 	 * The type of the editor interface.
 	 *
-	 * By default editor interface will be initialized as `divarea` editor which is an inline editor with fixed UI.
-	 * You can change interface type by choosing between `divarea` and `inline` editor interface types.
+	 * By default editor interface will be initialized as `classic` editor.
+	 * You can also choose to create an editor with `inline` or `divarea` interface type instead.
 	 *
 	 * See https://ckeditor.com/docs/ckeditor4/latest/guide/dev_uitypes.html
 	 * and https://ckeditor.com/docs/ckeditor4/latest/examples/fixedui.html

--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -40,6 +40,7 @@ declare let CKEDITOR: any;
 export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValueAccessor {
 	/**
 	 * The configuration of the editor.
+	 *
 	 * See https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html
 	 * to learn more.
 	 */
@@ -56,7 +57,7 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 	 * The type of the editor interface.
 	 *
 	 * By default editor interface will be initialized as `classic` editor.
-	 * You can also choose to create an editor with `inline` or `divarea` interface type instead.
+	 * You can also choose to create an editor with `inline` interface type instead.
 	 *
 	 * See https://ckeditor.com/docs/ckeditor4/latest/guide/dev_uitypes.html
 	 * and https://ckeditor.com/docs/ckeditor4/latest/examples/fixedui.html
@@ -84,7 +85,6 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 		}
 
 		this._data = data;
-
 	}
 
 	get data(): string {
@@ -92,8 +92,9 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 	}
 
 	/**
-	 * When set `true`, the editor becomes read-only.
-	 * https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#property-readOnly
+	 * When set to `true`, the editor becomes read-only.
+	 *
+	 * See https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#property-readOnly
 	 * to learn more.
 	 */
 	@Input() set readOnly( isReadOnly: boolean ) {
@@ -147,14 +148,14 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 	@Output() dataChange = new EventEmitter<CKEditor4.EventInfo>();
 
 	/**
-	 * Fires when the native drop event occurs. It corresponds with the `editor#dragstart`
+	 * Fires when the native dragStart event occurs. It corresponds with the `editor#dragstart`
 	 * https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#event-dragstart
 	 * event.
 	 */
 	@Output() dragStart = new EventEmitter<CKEditor4.EventInfo>();
 
 	/**
-	 * Fires when the native drop event occurs. It corresponds with the `editor#dragend`
+	 * Fires when the native dragEnd event occurs. It corresponds with the `editor#dragend`
 	 * https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#event-dragend
 	 * event.
 	 */
@@ -182,7 +183,7 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 	@Output() fileUploadRequest = new EventEmitter<CKEditor4.EventInfo>();
 
 	/**
-	 * Fires when the editing view of the editor is focused. It corresponds with the `editor#focus`
+	 * Fires when the editing area of the editor is focused. It corresponds with the `editor#focus`
 	 * https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#event-focus
 	 * event.
 	 */

--- a/src/ckeditor/ckeditor.ts
+++ b/src/ckeditor/ckeditor.ts
@@ -27,7 +27,6 @@ export namespace CKEditor4 {
 	 * to learn more.
 	 */
 	export const enum EditorType {
-		DIVAREA = 'divarea',
 		INLINE = 'inline',
 		CLASSIC = 'classic'
 	}

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -17,7 +17,7 @@
  // (window as any).__Zone_disable_on_property = true; // disable patch onProperty such as onclick
  // (window as any).__zone_symbol__BLACK_LISTED_EVENTS = ['scroll', 'mousemove']; // disable patch specified eventNames
 
- /*
+/**
  * in IE/Edge developer tools, the addEventListener will also be wrapped by zone.js
  * with the following flag, it will bypass `zone.js` patch for IE/Edge
  */
@@ -25,8 +25,7 @@
 
 /***************************************************************************************************
  * Browser Polyfills
- * IE11 needs those in general. Currently we use only some of them in tests using console and ensuring that 'divarea' plugin is loaded,
- * but they may come in handy later.
+ * IE11 needs those in general. Currently we use only some of them, but they may come in handy later.
  */
 
 import 'core-js/es/symbol';


### PR DESCRIPTION
EDIT:
This PR now removes the `divarea` editor type instead.

Proposed changelog entry (`2.0.0`):

```
* [#130](https://github.com/ckeditor/ckeditor4-angular/issues/130): `Divarea` is no longer treated as the separate editor type. [`divarea` plugin](https://ckeditor.com/cke4/addon/divarea) can still be used just by adding it to the custom configuration. 
```

~~This PR contains:~~
~~- API docs fix (update info that `classic` editor is the default one, not `divarea`);~~
~~- tests fix (tests for warning messages were failing);~~
~~- mechanism adding `floatingspace` plugin to the build if it is in `removePlugins` config and the editor type is `inline` (so analogous to the `divarea` editor type) together with unit tests;~~
~~- some minor refactoring.~~

~~I'd say there is still some code that could use a refactor (e.g. `removePlugin()` method), but it wasn't the subject of this PR so I didn't touch it now.~~

~~Short note about tests - changing from `beforeEach()` to `beforeAll()` (which was reverting the recent change introduced in https://github.com/ckeditor/ckeditor4-angular/commit/ebf6aed2f7db7866747b8121f50773043e64a2dd) was necessary as the config was changing after it was passed to the component. Now the config is updated properly, i.e. before the `describe()` block that contains it. And it is separate for each editor type and each config suit, so everything works fine.~~

Closes #130.