### PR TITLE
Introduce GH action for NPM deps bulk update

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -2,7 +2,7 @@ name: Update NPM dependencies
 
 on:
   schedule:
-  - cron: "*/5 * * * *"
+  - cron: "*/10 * * * *"
 
 jobs:
   update:
@@ -19,15 +19,15 @@ jobs:
         # GITHUB_USEREMAIL - GH user email which will be used to push changes.
         # [BRANCH_MAIN] - Main branch name (optional), if not set GITHUB_REF will be used.
         run: |
-          if [[ -z ${{ secrets.GITHUB_USERNAME }} ]]; then
+          if [[ -z "${{ secrets.GITHUB_USERNAME }}" ]]; then
             echo "Expected 'GITHUB_USERNAME' secret variable to be set. Current value '${{ secrets.GITHUB_USERNAME }}'"
             exit 1
           fi
-          if [[ -z ${{ secrets.GITHUB_USEREMAIL }} ]]; then
+          if [[ -z "${{ secrets.GITHUB_USEREMAIL }}" ]]; then
             echo "Expected 'GITHUB_USEREMAIL' secret variable to be set. Current value '${{ secrets.GITHUB_USEREMAIL }}'"
             exit 1
           fi
-          if [[ -z ${{ secrets.BRANCH_MAIN }} ]]; then
+          if [[ -z "${{ secrets.BRANCH_MAIN }}" ]]; then
             echo "BRANCH_MAIN=${{ env.GITHUB_REF }}" >> $GITHUB_ENV
           else
             echo "BRANCH_MAIN=${{ secrets.BRANCH_MAIN }}" >> $GITHUB_ENV

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -28,8 +28,7 @@ jobs:
             exit 1
           fi
           if [[ -z "${{ secrets.BRANCH_MAIN }}" ]]; then
-            DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
-            echo "BRANCH_MAIN=${{ DEFAULT_BRANCH }}" >> $GITHUB_ENV
+            echo "BRANCH_MAIN=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')" >> $GITHUB_ENV
           else
             echo "BRANCH_MAIN=${{ secrets.BRANCH_MAIN }}" >> $GITHUB_ENV
           fi

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -54,11 +54,11 @@ jobs:
         if: env.HAS_CHANGES == 1
         # https://github.com/marketplace/actions/initialize-pull-request
         uses: gha-utilities/init-pull-request@v0.2.0
-          with:
-            verbose: true
-            pull_request_token: ${{ secrets.GITHUB_TOKEN }}
-            head: deps-update_${{ matrix.deps }}
-            base: master
-            title: 'Update NPM ${{ matrix.deps }} dependencies'
-            body: >
-              Updated NPM ${{ matrix.deps }} dependencies.
+        with:
+          verbose: true
+          pull_request_token: ${{ secrets.GITHUB_TOKEN }}
+          head: deps-update_${{ matrix.deps }}
+          base: master
+          title: 'Update NPM ${{ matrix.deps }} dependencies'
+          body: >
+            Updated NPM ${{ matrix.deps }} dependencies.

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -1,0 +1,52 @@
+name: Update NPM dependencies
+
+on:
+  schedule:
+  - cron: "0 14,15,16 * * *"
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        deps: [production, dev-only]
+
+    steps:
+      - name: Fetch changes
+        # https://github.com/marketplace/actions/checkout
+        uses: actions/checkout@v2
+        with:
+          ref: master
+
+      - name: Setup
+        # https://github.com/marketplace/actions/setup-node-js-environment
+        uses: actions/setup-node@v2-beta
+        with:
+          node-version: '12'
+        run: |
+          npm i
+          npm install -g npm-check
+
+      - name: Update dependencies
+        run: |
+          git checkout -b deps-update_${{ matrix.deps }}
+          npm-check -y --${{ matrix.deps }}
+
+      - name: Push changes
+        run: |
+          if [[ $(git diff origin/master | wc -c) -ne 0 ]]; then
+            git config --local user.email "ckeditor-bot@cksource.com"
+            git config --local user.name "CKEditor Bot"
+            git add package*.json
+            git commit -m "Update NPM ${{ matrix.deps }} dependencies."
+            echo "HAS_CHANGES=1" >> $GITHUB_ENV
+          fi
+
+      - name: Push changes
+        if: env.HAS_CHANGES == 1
+        # https://github.com/marketplace/actions/github-push
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: deps-update_${{ matrix.deps }}

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -2,7 +2,7 @@ name: Update NPM dependencies
 
 on:
   schedule:
-  - cron: "0 5 * * 1"
+  - cron: "*/10 * * * *"
 
 jobs:
   update:

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -2,7 +2,7 @@ name: Update NPM dependencies
 
 on:
   schedule:
-  - cron: "*/10 12,13,14 * * *"
+  - cron: "0 5 * * 1"
 
 jobs:
   update:

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -2,7 +2,7 @@ name: Update NPM dependencies
 
 on:
   schedule:
-  - cron: "0 5 * * 1"
+  - cron: "*/5 * * * *"
 
 jobs:
   update:

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -13,11 +13,31 @@ jobs:
         deps: [production, dev-only]
 
     steps:
+      - name: Check env variables
+        # Expected secrets variables:
+        # GITHUB_USERNAME - GH user name which will be used to push changes.
+        # GITHUB_USEREMAIL - GH user email which will be used to push changes.
+        # [BRANCH_MAIN] - Main branch name (optional), if not set GITHUB_REF will be used.
+        run: |
+          if [[ -z ${{ secrets.GITHUB_USERNAME }} ]]; then
+            echo "Expected 'GITHUB_USERNAME' secret variable to be set. Current value '${{ secrets.GITHUB_USERNAME }}'"
+            exit 1
+          fi
+          if [[ -z ${{ secrets.GITHUB_USEREMAIL }} ]]; then
+            echo "Expected 'GITHUB_USEREMAIL' secret variable to be set. Current value '${{ secrets.GITHUB_USEREMAIL }}'"
+            exit 1
+          fi
+          if [[ -z ${{ secrets.BRANCH_MAIN }} ]]; then
+            echo "BRANCH_MAIN=${{ env.GITHUB_REF }}" >> $GITHUB_ENV
+          else
+            echo "BRANCH_MAIN=${{ secrets.BRANCH_MAIN }}" >> $GITHUB_ENV
+          fi
+
       - name: Fetch changes
         # https://github.com/marketplace/actions/checkout
         uses: actions/checkout@v2
         with:
-          ref: master
+          ref: ${{ env.BRANCH_MAIN }}
 
       - name: Setup node
         # https://github.com/marketplace/actions/setup-node-js-environment
@@ -25,27 +45,27 @@ jobs:
         with:
           node-version: '12'
 
-      - name: Is update possible
+      - name: Check if update branch already exists
         run: |
-          echo "BRANCH_NAME=deps-update_${{ matrix.deps }}" >> $GITHUB_ENV
+          echo "BRANCH_UPDATE=deps-update_${{ matrix.deps }}" >> $GITHUB_ENV
           if [[ $(git ls-remote --heads | grep deps-update_${{ matrix.deps }} | wc -c) -ne 0 ]]; then
-            echo "BRANCH_NAME=0" >> $GITHUB_ENV
+            echo "BRANCH_UPDATE=0" >> $GITHUB_ENV
           fi
 
       - name: Update NPM dependencies
-        if: env.BRANCH_NAME != 0
+        if: env.BRANCH_UPDATE != 0
         run: |
           npm i
           npm install -g npm-check
-          git checkout -b ${{ env.BRANCH_NAME }}
+          git checkout -b ${{ env.BRANCH_UPDATE }}
           npm-check -y --${{ matrix.deps }}
 
       - name: Add changes
-        if: env.BRANCH_NAME != 0
+        if: env.BRANCH_UPDATE != 0
         run: |
-          if [[ $(git diff origin/master | wc -c) -ne 0 ]]; then
-            git config --local user.email "ckeditor-bot@cksource.com"
-            git config --local user.name "CKEditor Bot"
+          if [[ $(git diff origin/${{ env.BRANCH_MAIN }} | wc -c) -ne 0 ]]; then
+            git config --local user.email "${{ secrets.GITHUB_USEREMAIL }}"
+            git config --local user.name "${{ secrets.GITHUB_USERNAME }}"
             git add package*.json
             git commit -m "Update NPM ${{ matrix.deps }} dependencies."
             echo "HAS_CHANGES=1" >> $GITHUB_ENV
@@ -57,15 +77,15 @@ jobs:
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ env.BRANCH_NAME }}
+          branch: ${{ env.BRANCH_UPDATE }}
 
       - name: Create PR
         if: env.HAS_CHANGES == 1
         # https://github.com/marketplace/actions/github-pull-request-action
         uses: repo-sync/pull-request@v2
         with:
-          source_branch: "${{ env.BRANCH_NAME }}"
-          destination_branch: "master"
+          source_branch: "${{ env.BRANCH_UPDATE }}"
+          destination_branch: "${{ env.BRANCH_MAIN }}"
           pr_title: "Update NPM ${{ matrix.deps }} dependencies"
           pr_body: "Updated NPM ${{ matrix.deps }} dependencies."
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -32,7 +32,7 @@ jobs:
             echo "BRANCH_NAME=0" >> $GITHUB_ENV
           fi
 
-      - name: Update dependencies
+      - name: Update NPM dependencies
         if: env.BRANCH_NAME != 0
         run: |
           npm i

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -2,7 +2,7 @@ name: Update NPM dependencies
 
 on:
   schedule:
-  - cron: "0 14,15,16 * * *"
+  - cron: "*/10 12,13,14 * * *"
 
 jobs:
   update:

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Check if update branch already exists
         run: |
           echo "BRANCH_UPDATE=deps-update_${{ env.BRANCH_MAIN }}_${{ matrix.deps }}" >> $GITHUB_ENV
-          if [[ $(git ls-remote --heads | grep deps-update_${{ matrix.deps }} | wc -c) -ne 0 ]]; then
+          if [[ $(git ls-remote --heads | grep deps-update_${{ env.BRANCH_MAIN }}_${{ matrix.deps }} | wc -c) -ne 0 ]]; then
             echo "BRANCH_UPDATE=0" >> $GITHUB_ENV
           fi
 

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           npm i
           npm install -g npm-check
-          git checkout -b deps-update_${{ matrix.deps }}
+          git checkout -b ${{ env.BRANCH_NAME }}
           npm-check -y --${{ matrix.deps }}
 
       - name: Add changes
@@ -57,17 +57,15 @@ jobs:
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: deps-update_${{ matrix.deps }}
+          branch: ${{ env.BRANCH_NAME }}
 
       - name: Create PR
         if: env.HAS_CHANGES == 1
-        # https://github.com/marketplace/actions/initialize-pull-request
-        uses: gha-utilities/init-pull-request@v0.1.9
+        # https://github.com/marketplace/actions/github-pull-request-action
+        uses: repo-sync/pull-request@v2
         with:
-          verbose: true
-          pull_request_token: ${{ secrets.GITHUB_TOKEN }}
-          head: deps-update_${{ matrix.deps }}
-          base: master
-          title: 'Update NPM ${{ matrix.deps }} dependencies'
-          body: >
-            Updated NPM ${{ matrix.deps }} dependencies.
+          source_branch: "${{ env.BRANCH_NAME }}"
+          destination_branch: "master"
+          pr_title: "Update NPM ${{ matrix.deps }} dependencies"
+          pr_body: "Updated NPM ${{ matrix.deps }} dependencies."
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -19,17 +19,16 @@ jobs:
         with:
           ref: master
 
-      - name: Setup
+      - name: Setup node
         # https://github.com/marketplace/actions/setup-node-js-environment
         uses: actions/setup-node@v2-beta
         with:
           node-version: '12'
-        run: |
-          npm i
-          npm install -g npm-check
 
       - name: Update dependencies
         run: |
+          npm i
+          npm install -g npm-check
           git checkout -b deps-update_${{ matrix.deps }}
           npm-check -y --${{ matrix.deps }}
 

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -15,16 +15,16 @@ jobs:
     steps:
       - name: Check env variables
         # Expected secrets variables:
-        # GITHUB_USERNAME - GH user name which will be used to push changes.
-        # GITHUB_USEREMAIL - GH user email which will be used to push changes.
+        # BOT_USERNAME - GH user name which will be used to push changes.
+        # BOT_EMAIL - GH user email which will be used to push changes.
         # [BRANCH_MAIN] - Main branch name (optional), if not set GITHUB_REF will be used.
         run: |
-          if [[ -z "${{ secrets.GITHUB_USERNAME }}" ]]; then
-            echo "Expected 'GITHUB_USERNAME' secret variable to be set. Current value '${{ secrets.GITHUB_USERNAME }}'"
+          if [[ -z "${{ secrets.BOT_USERNAME }}" ]]; then
+            echo "Expected 'BOT_USERNAME' secret variable to be set. Current value '${{ secrets.BOT_USERNAME }}'"
             exit 1
           fi
-          if [[ -z "${{ secrets.GITHUB_USEREMAIL }}" ]]; then
-            echo "Expected 'GITHUB_USEREMAIL' secret variable to be set. Current value '${{ secrets.GITHUB_USEREMAIL }}'"
+          if [[ -z "${{ secrets.BOT_EMAIL }}" ]]; then
+            echo "Expected 'BOT_EMAIL' secret variable to be set. Current value '${{ secrets.BOT_EMAIL }}'"
             exit 1
           fi
           if [[ -z "${{ secrets.BRANCH_MAIN }}" ]]; then
@@ -64,8 +64,8 @@ jobs:
         if: env.BRANCH_UPDATE != 0
         run: |
           if [[ $(git diff origin/${{ env.BRANCH_MAIN }} | wc -c) -ne 0 ]]; then
-            git config --local user.email "${{ secrets.GITHUB_USEREMAIL }}"
-            git config --local user.name "${{ secrets.GITHUB_USERNAME }}"
+            git config --local user.email "${{ secrets.BOT_EMAIL }}"
+            git config --local user.name "${{ secrets.BOT_USERNAME }}"
             git add package*.json
             git commit -m "Update NPM ${{ matrix.deps }} dependencies."
             echo "HAS_CHANGES=1" >> $GITHUB_ENV

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Is update possible
         run: |
           echo "BRANCH_NAME=deps-update_${{ matrix.deps }}" >> $GITHUB_ENV
-          if [[ $(git ls-remote --heads | grep ${{ env.BRANCH_NAME }} | wc -c) -ne 0 ]]; then
+          if [[ $(git ls-remote --heads | grep deps-update_${{ matrix.deps }} | wc -c) -ne 0 ]]; then
             echo "BRANCH_NAME=0" >> $GITHUB_ENV
           fi
 

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -32,7 +32,7 @@ jobs:
           git checkout -b deps-update_${{ matrix.deps }}
           npm-check -y --${{ matrix.deps }}
 
-      - name: Push changes
+      - name: Add changes
         run: |
           if [[ $(git diff origin/master | wc -c) -ne 0 ]]; then
             git config --local user.email "ckeditor-bot@cksource.com"
@@ -49,3 +49,16 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: deps-update_${{ matrix.deps }}
+
+        - name: Create PR
+          if: env.HAS_CHANGES == 1
+          # https://github.com/marketplace/actions/initialize-pull-request
+          uses: gha-utilities/init-pull-request@v0.2.0
+            with:
+              verbose: true
+              pull_request_token: ${{ secrets.GITHUB_TOKEN }}
+              head: deps-update_${{ matrix.deps }}
+              base: master
+              title: 'Update NPM ${{ matrix.deps }} dependencies'
+              body: >
+                Updated NPM ${{ matrix.deps }} dependencies.

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -17,7 +17,7 @@ jobs:
         # Expected secrets variables:
         # BOT_USERNAME - GH user name which will be used to push changes.
         # BOT_EMAIL - GH user email which will be used to push changes.
-        # [BRANCH_MAIN] - Main branch name (optional), if not set GITHUB_REF will be used.
+        # [BRANCH_MAIN] - Target branch name (optional), if not set default branch will be used.
         run: |
           if [[ -z "${{ secrets.BOT_USERNAME }}" ]]; then
             echo "Expected 'BOT_USERNAME' secret variable to be set. Current value '${{ secrets.BOT_USERNAME }}'"
@@ -28,7 +28,8 @@ jobs:
             exit 1
           fi
           if [[ -z "${{ secrets.BRANCH_MAIN }}" ]]; then
-            echo "BRANCH_MAIN=${{ env.GITHUB_REF }}" >> $GITHUB_ENV
+            DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
+            echo "BRANCH_MAIN=${{ DEFAULT_BRANCH }}" >> $GITHUB_ENV
           else
             echo "BRANCH_MAIN=${{ secrets.BRANCH_MAIN }}" >> $GITHUB_ENV
           fi

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -2,7 +2,7 @@ name: Update NPM dependencies
 
 on:
   schedule:
-  - cron: "*/10 * * * *"
+  - cron: "0 5 * * 1"
 
 jobs:
   update:

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -13,6 +13,16 @@ jobs:
         deps: [production, dev-only]
 
     steps:
+      - name: Setup node
+        # https://github.com/marketplace/actions/setup-node-js-environment
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12'
+
+      - name: Fetch changes
+        # https://github.com/marketplace/actions/checkout
+        uses: actions/checkout@v2
+
       - name: Check env variables
         # Expected secrets variables:
         # BOT_USERNAME - GH user name which will be used to push changes.
@@ -28,22 +38,11 @@ jobs:
             exit 1
           fi
           if [[ -z "${{ secrets.BRANCH_MAIN }}" ]]; then
-            echo "BRANCH_MAIN=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')" >> $GITHUB_ENV
+            # Since 'Fetch changes' step fetches default branch, we just get branch name (which will be default one).
+            echo "BRANCH_MAIN=$(git rev-parse --abbrev-ref HEAD)" >> $GITHUB_ENV
           else
             echo "BRANCH_MAIN=${{ secrets.BRANCH_MAIN }}" >> $GITHUB_ENV
           fi
-
-      - name: Fetch changes
-        # https://github.com/marketplace/actions/checkout
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ env.BRANCH_MAIN }}
-
-      - name: Setup node
-        # https://github.com/marketplace/actions/setup-node-js-environment
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12'
 
       - name: Check if update branch already exists
         run: |

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -25,7 +25,15 @@ jobs:
         with:
           node-version: '12'
 
+      - name: Is update possible
+        run: |
+          echo "BRANCH_NAME=deps-update_${{ matrix.deps }}" >> $GITHUB_ENV
+          if [[ $(git ls-remote --heads | grep ${{ env.BRANCH_NAME }} | wc -c) -ne 0 ]]; then
+            echo "BRANCH_NAME=0" >> $GITHUB_ENV
+          fi
+
       - name: Update dependencies
+        if: env.BRANCH_NAME != 0
         run: |
           npm i
           npm install -g npm-check
@@ -33,6 +41,7 @@ jobs:
           npm-check -y --${{ matrix.deps }}
 
       - name: Add changes
+        if: env.BRANCH_NAME != 0
         run: |
           if [[ $(git diff origin/master | wc -c) -ne 0 ]]; then
             git config --local user.email "ckeditor-bot@cksource.com"

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Check if update branch already exists
         run: |
-          echo "BRANCH_UPDATE=deps-update_${{ matrix.deps }}" >> $GITHUB_ENV
+          echo "BRANCH_UPDATE=deps-update_${{ env.BRANCH_MAIN }}_${{ matrix.deps }}" >> $GITHUB_ENV
           if [[ $(git ls-remote --heads | grep deps-update_${{ matrix.deps }} | wc -c) -ne 0 ]]; then
             echo "BRANCH_UPDATE=0" >> $GITHUB_ENV
           fi

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Create PR
         if: env.HAS_CHANGES == 1
         # https://github.com/marketplace/actions/initialize-pull-request
-        uses: gha-utilities/init-pull-request@v0.2.0
+        uses: gha-utilities/init-pull-request@v0.1.9
         with:
           verbose: true
           pull_request_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Setup node
         # https://github.com/marketplace/actions/setup-node-js-environment
-        uses: actions/setup-node@v2-beta
+        uses: actions/setup-node@v1
         with:
           node-version: '12'
 

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -50,15 +50,15 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: deps-update_${{ matrix.deps }}
 
-        - name: Create PR
-          if: env.HAS_CHANGES == 1
-          # https://github.com/marketplace/actions/initialize-pull-request
-          uses: gha-utilities/init-pull-request@v0.2.0
-            with:
-              verbose: true
-              pull_request_token: ${{ secrets.GITHUB_TOKEN }}
-              head: deps-update_${{ matrix.deps }}
-              base: master
-              title: 'Update NPM ${{ matrix.deps }} dependencies'
-              body: >
-                Updated NPM ${{ matrix.deps }} dependencies.
+      - name: Create PR
+        if: env.HAS_CHANGES == 1
+        # https://github.com/marketplace/actions/initialize-pull-request
+        uses: gha-utilities/init-pull-request@v0.2.0
+          with:
+            verbose: true
+            pull_request_token: ${{ secrets.GITHUB_TOKEN }}
+            head: deps-update_${{ matrix.deps }}
+            base: master
+            title: 'Update NPM ${{ matrix.deps }} dependencies'
+            body: >
+              Updated NPM ${{ matrix.deps }} dependencies.


### PR DESCRIPTION
See https://github.com/f1ames/ckeditor4-angular/actions and https://github.com/f1ames/ckeditor4-angular/pulls.

As @Comandeer mentioned:

> `npm update` respects semver, so it won't e.g. update dev dep to the new major version.

and so I have used [`npm-check` package](https://www.npmjs.com/package/npm-check). This action also check if update devs branch already exists and skips updating if so (so it gives as time to check it).

I guess we could squash commits in this branch before merging too.