### PR TITLE
Add support for `config.delayIfDetached`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CKEditor 4 Angular Integration Changelog
 
+## ckeditor4-angular 2.3.1
+
+Other changes:
+
+* Add support for `config.delayIfDetached` config option.
+
 ## ckeditor4-angular 2.3.0
 
 Other Changes:

--- a/e2e/src/app.e2e-spec.ts
+++ b/e2e/src/app.e2e-spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { AppPage } from './app.po';
-import { protractor, WebElement } from 'protractor';
+import { element, by, protractor, WebElement } from 'protractor';
 
 describe( 'workspace-project App', () => {
 	let page: AppPage,
@@ -57,6 +57,23 @@ describe( 'workspace-project App', () => {
 		} );
 
 		it( `typing should update editor content`, testTyping( 0 ) );
+	} );
+
+	describe( 'detachable-component', () => {
+		beforeEach( () => {
+			page.navigateTo( 'detachable' );
+		} );
+
+		it( 'should allow to attach editor with initial content', async () => {
+			const button = element( by.css( 'button' ) );
+
+			button.click();
+
+			const editable = await page.getEditable();
+
+			expect( page.getHtmlString( editable ) )
+				.toBe( '<p>Hi, I am CKEditor 4!</p>' );
+		} );
 	} );
 
 	function testTyping( elementIndex: number ) {

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -4,6 +4,7 @@
 	<ul>
 		<li><a routerLink="/simple-usage" routerLinkActive="active">Simple usage</a></li>
 		<li><a routerLink="/forms" routerLinkActive="active">Integration with forms (<code>ngModel</code>)</a></li>
+		<li><a routerLink="/detachable" routerLinkActive="active">Detachable component</a></li>
 	</ul>
 </nav>
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -12,11 +12,13 @@ import { AppComponent } from './app.component';
 import { CKEditorModule } from '../ckeditor/ckeditor.module';
 import { SimpleUsageComponent } from './simple-usage/simple-usage.component';
 import { DemoFormComponent } from './demo-form/demo-form.component';
+import { DetachableComponent } from './detachable-component/detachable-component.component';
 
 const appRoutes: Routes = [
 	{ path: '', redirectTo: '/simple-usage', pathMatch: 'full' },
 	{ path: 'simple-usage', component: SimpleUsageComponent },
-	{ path: 'forms', component: DemoFormComponent }
+	{ path: 'forms', component: DemoFormComponent },
+	{ path: 'detachable', component: DetachableComponent }
 ];
 
 @NgModule( {
@@ -29,7 +31,8 @@ const appRoutes: Routes = [
 	declarations: [
 		AppComponent,
 		DemoFormComponent,
-		SimpleUsageComponent
+		SimpleUsageComponent,
+		DetachableComponent
 	],
 	providers: [],
 	bootstrap: [ AppComponent ]

--- a/src/app/detachable-component/detachable-component.component.css
+++ b/src/app/detachable-component/detachable-component.component.css
@@ -1,0 +1,9 @@
+/**
+ * @license Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+:host ::ng-deep .ck.ck-editor__editable:not([contenteditable]) {
+	background: #fafafa;
+	color: #888;
+}

--- a/src/app/detachable-component/detachable-component.component.html
+++ b/src/app/detachable-component/detachable-component.component.html
@@ -5,7 +5,7 @@
 	<h3>Detachable editor:</h3>
 	<div #container>
 		<div #editor>
-			<ckeditor data="<p>Hi, I am CKEditor 4!</p>"></ckeditor>
+			<ckeditor data="<p>Hi, I am CKEditor 4!</p>" [config]="{ extraPlugins: 'divarea' }"></ckeditor>
 		</div>
 	</div>
 

--- a/src/app/detachable-component/detachable-component.component.html
+++ b/src/app/detachable-component/detachable-component.component.html
@@ -1,0 +1,12 @@
+<h2>Detachable example</h2>
+
+<p><strong>Note:</strong> Open the console for additional logs.</p>
+
+	<h3>Detachable editor:</h3>
+	<div #container>
+		<div #editor>
+			<ckeditor data="<p>Hi, I am CKEditor 4!</p>"></ckeditor>
+		</div>
+	</div>
+
+<p><button *ngIf="!isReattached" (click)="reattachEditor()">Reattach the editor</button></p>

--- a/src/app/detachable-component/detachable-component.component.spec.ts
+++ b/src/app/detachable-component/detachable-component.component.spec.ts
@@ -42,7 +42,7 @@ describe( 'DetachableComponent', () => {
 		fixture.destroy();
 	} );
 
-	it( 'should create editor after adding it the DOM without throwing any errors ', async done => {
+	it( 'should create editor after adding it the DOM without throwing any errors ', async () => {
 		fixture = TestBed.createComponent( DetachableComponent );
 		component = fixture.componentInstance;
 
@@ -58,7 +58,7 @@ describe( 'DetachableComponent', () => {
 
 		component.reattachEditor();
 
-		whenEach( ckeditorComponent => whenEvent( 'ready', ckeditorComponent ) ).then( done );
+		return whenEach( ckeditorComponent => whenEvent( 'ready', ckeditorComponent ) );
 	} );
 
 	function whenEach( callback ) {

--- a/src/app/detachable-component/detachable-component.component.spec.ts
+++ b/src/app/detachable-component/detachable-component.component.spec.ts
@@ -1,0 +1,73 @@
+/**
+ * @license Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { DebugElement } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { By } from '@angular/platform-browser';
+
+import { DetachableComponent } from './detachable-component.component';
+import { getEditorNamespace } from 'ckeditor4-integrations-common';
+import { CKEditorModule } from '../../ckeditor/ckeditor.module';
+import { CKEditorComponent } from '../../ckeditor/ckeditor.component';
+import { whenEvent } from '../../test.tools';
+
+import Spy = jasmine.Spy;
+
+describe( 'DetachableComponent', () => {
+	let component: DetachableComponent,
+		fixture: ComponentFixture<DetachableComponent>,
+		ckeditorComponents: CKEditorComponent[],
+		debugElements: DebugElement[],
+		spy: Spy;
+
+	beforeEach( async( () => {
+		TestBed.configureTestingModule( {
+			declarations: [ DetachableComponent ],
+			imports: [ CKEditorModule, FormsModule ]
+		} ).compileComponents();
+	} ) );
+
+	afterEach( done => {
+		whenEach( ckeditorComponent =>
+			new Promise( res => {
+				if ( ckeditorComponent.instance ) {
+					ckeditorComponent.instance.once( 'destroy', res );
+				}
+			} )
+		).then( done );
+
+		fixture.destroy();
+	} );
+
+	it( 'should create editor after adding it the DOM without throwing any errors ', async done => {
+		fixture = TestBed.createComponent( DetachableComponent );
+		component = fixture.componentInstance;
+
+		// When there is `*ngIf` directive on component instance, we need another detectChanges.
+		fixture.detectChanges();
+
+		debugElements = fixture.debugElement.queryAll( By.directive( CKEditorComponent ) );
+		ckeditorComponents = debugElements.map( debugElement => debugElement.componentInstance );
+
+		fixture.detectChanges();
+
+		await wait( 500 );
+
+		component.reattachEditor();
+
+		whenEach( ckeditorComponent => whenEvent( 'ready', ckeditorComponent ) ).then( done );
+	} );
+
+	function whenEach( callback ) {
+		return Promise.all( ckeditorComponents.map( ckeditorComponent => callback( ckeditorComponent ) ) );
+	}
+
+	function wait( time ) {
+		return new Promise( resolve => {
+			setTimeout( resolve, time );
+		} );
+	}
+} );

--- a/src/app/detachable-component/detachable-component.component.ts
+++ b/src/app/detachable-component/detachable-component.component.ts
@@ -1,0 +1,31 @@
+/**
+ * @license Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import { AfterViewInit, Component, ElementRef, ViewChild } from '@angular/core';
+
+@Component( {
+	selector: 'app-detachable-component',
+	templateUrl: './detachable-component.component.html',
+	styleUrls: [ './detachable-component.component.css' ]
+} )
+export class DetachableComponent implements AfterViewInit {
+	isReattached = false;
+
+	@ViewChild( 'container' ) private containerElement: ElementRef;
+	@ViewChild( 'editor' ) private editorElement: ElementRef;
+
+	ngAfterViewInit(): void {
+		console.log( 'Component loaded, deataching' );
+
+		this.editorElement.nativeElement.remove();
+	}
+
+	reattachEditor() {
+		console.log( 'Button clicked, reattaching editor' );
+
+		this.isReattached = true;
+		this.containerElement.nativeElement.append( this.editorElement.nativeElement );
+	}
+}

--- a/src/app/detachable-component/detachable-component.component.ts
+++ b/src/app/detachable-component/detachable-component.component.ts
@@ -19,13 +19,13 @@ export class DetachableComponent implements AfterViewInit {
 	ngAfterViewInit(): void {
 		console.log( 'Component loaded, deataching' );
 
-		this.editorElement.nativeElement.remove();
+		this.containerElement.nativeElement.removeChild( this.editorElement.nativeElement );
 	}
 
 	reattachEditor() {
 		console.log( 'Button clicked, reattaching editor' );
 
 		this.isReattached = true;
-		this.containerElement.nativeElement.append( this.editorElement.nativeElement );
+		this.containerElement.nativeElement.appendChild( this.editorElement.nativeElement );
 	}
 }

--- a/src/ckeditor/ckeditor.component.spec.ts
+++ b/src/ckeditor/ckeditor.component.spec.ts
@@ -470,3 +470,70 @@ describe( 'CKEditorComponent', () => {
 		} );
 	} );
 } );
+
+// (#190)
+describe( 'CKEditorComponent detached', () => {
+	let fixture: ComponentFixture<CKEditorComponent>
+
+	beforeEach( () => {
+		return TestBed.configureTestingModule( {
+			declarations: [ CKEditorComponent ]
+		} ).compileComponents();
+	} )
+
+	// beforeEach( () => {
+	// 	fixture = TestBed.createComponent( CKEditorComponent );
+	// 	component = fixture.componentInstance;
+	// 	component.config = config;
+
+	// 	fixture.detectChanges();
+	// } );
+
+	afterEach( () => {
+		if ( fixture ) {
+			fixture.destroy();
+		}
+	} );
+
+	it( 'should set config.delayIfDetached to true by default', async () => {
+		fixture = TestBed.createComponent( CKEditorComponent );
+		const component = fixture.componentInstance;
+
+		fixture.detectChanges();
+
+		await whenEvent( 'ready', component );
+
+		expect( component.instance.config.delayIfDetached ).toBeTrue();
+	} );
+
+	it( 'should allow overriding config.delayIfDetached', async () => {
+		fixture = TestBed.createComponent( CKEditorComponent );
+		const component = fixture.componentInstance;
+		component.config = {
+			delayIfDetached: false
+		};
+
+		fixture.detectChanges();
+
+		await whenEvent( 'ready', component );
+
+		expect( component.instance.config.delayIfDetached ).toBeFalse();
+	} );
+
+	it( 'should invoke user provided config.on.instanceReady', async () => {
+		fixture = TestBed.createComponent( CKEditorComponent );
+		const spy = jasmine.createSpy();
+		const component = fixture.componentInstance;
+		component.config = {
+			on: {
+				instanceReady: spy
+			}
+		};
+
+		fixture.detectChanges();
+
+		await whenEvent( 'ready', component );
+
+		expect( spy ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/src/ckeditor/ckeditor.component.spec.ts
+++ b/src/ckeditor/ckeditor.component.spec.ts
@@ -479,15 +479,7 @@ describe( 'CKEditorComponent detached', () => {
 		return TestBed.configureTestingModule( {
 			declarations: [ CKEditorComponent ]
 		} ).compileComponents();
-	} )
-
-	// beforeEach( () => {
-	// 	fixture = TestBed.createComponent( CKEditorComponent );
-	// 	component = fixture.componentInstance;
-	// 	component.config = config;
-
-	// 	fixture.detectChanges();
-	// } );
+	} );
 
 	afterEach( () => {
 		if ( fixture ) {

--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
- import {
+import {
 	Component,
 	NgZone,
 	Input,

--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-import {
+ import {
 	Component,
 	NgZone,
 	Input,
@@ -299,41 +299,60 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 		const element = document.createElement( this.tagName );
 		this.elementRef.nativeElement.appendChild( element );
 
-		const instance: CKEditor4.Editor = this.type === CKEditor4.EditorType.INLINE
-			? CKEDITOR.inline( element, this.config )
-			: CKEDITOR.replace( element, this.config );
+		const userInstanceReadyCallback = this.config?.on?.instanceReady;
+		const defaultConfig: Partial<CKEditor4.Config> = {
+			delayIfDetached: true
+		};
+		const config: Partial<CKEditor4.Config> = { ...defaultConfig, ...this.config };
 
-		instance.once( 'instanceReady', evt => {
-			this.instance = instance;
+		if ( typeof config.on === 'undefined' ) {
+			config.on = {};
+		}
+
+		config.on.instanceReady = evt => {
+			const editor = evt.editor;
+
+			this.instance = editor;
 
 			// Read only state may change during instance initialization.
 			this.readOnly = this._readOnly !== null ? this._readOnly : this.instance.readOnly;
 
 			this.subscribe( this.instance );
 
-			const undo = instance.undoManager;
+			const undo = editor.undoManager;
 
 			if ( this.data !== null ) {
 				undo && undo.lock();
 
-				instance.setData( this.data, { callback: () => {
+				editor.setData( this.data, { callback: () => {
 					// Locking undoManager prevents 'change' event.
 					// Trigger it manually to updated bound data.
-					if ( this.data !== instance.getData() ) {
-						undo ? instance.fire( 'change' ) : instance.fire( 'dataReady' );
+					if ( this.data !== editor.getData() ) {
+						undo ? editor.fire( 'change' ) : editor.fire( 'dataReady' );
 					}
 					undo && undo.unlock();
 
 					this.ngZone.run( () => {
+						if ( typeof userInstanceReadyCallback === 'function' ) {
+							userInstanceReadyCallback( evt );
+						}
+
 						this.ready.emit( evt );
 					} );
 				} } );
 			} else {
 				this.ngZone.run( () => {
+					if ( typeof userInstanceReadyCallback === 'function' ) {
+						userInstanceReadyCallback( evt );
+					}
+
 					this.ready.emit( evt );
 				} );
 			}
-		} );
+		}
+
+		this.type === CKEditor4.EditorType.INLINE ? CKEDITOR.inline( element, config ) :
+			CKEDITOR.replace( element, config );
 	}
 
 	private subscribe( editor: any ): void {


### PR DESCRIPTION
This PR adds support for `config.delayIfDetached` and a sample component with a detachable editor's component.

Closes #190.