### PR TITLE
Editor name - if init target has ID, use ID as editor name.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,12 @@
 	"author": "CKSource (https://cksource.com/)",
 	"license": "SEE LICENSE IN LICENSE.md",
 	"homepage": "https://ckeditor.com/",
-	"bugs": "https://github.com/ckeditor/ckeditor4-angular/issues",
+	"bugs": {
+		"url": "https://github.com/ckeditor/ckeditor4-angular/issues"
+	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/ckeditor/ckeditor4-angular.git"
+		"url": "git+https://github.com/ckeditor/ckeditor4-angular.git"
 	},
 	"private": true,
 	"dependencies": {
@@ -44,7 +46,7 @@
 		"@angular/router": "^13.4.0",
 		"@types/jasmine": "^4.3.1",
 		"@types/jasminewd2": "^2.0.10",
-		"@types/node": "^18.13.0",
+		"@types/node": "^16.11.7",
 		"browserslist": "^4.21.5",
 		"classlist.js": "^1.1.20150312",
 		"codelyzer": "^6.0.2",
@@ -66,7 +68,7 @@
 		"ts-node": "^10.9.1",
 		"tslib": "^2.5.0",
 		"tslint": "^6.1.3",
-		"typescript": "4.6.4",
+		"typescript": "^4.6.4",
 		"wait-until-promise": "^1.0.0",
 		"zone.js": "^0.11.8"
 	},

--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -297,6 +297,13 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 
 	private createEditor(): void {
 		const element = document.createElement( this.tagName );
+        const elementId = this.elementRef.nativeElement.id;
+
+        // if the user has specified an id on the node in which they're initializing on, use that ID as the name of the editor!
+        if ( elementId ) {
+            element.id = elementId;
+        }
+        
 		this.elementRef.nativeElement.appendChild( element );
 
 		const userInstanceReadyCallback = this.config?.on?.instanceReady;

--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -304,6 +304,7 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 
             // update
 			// cache-busting
+            // test commit
 			CKEDITOR.timestamp = new Date().getTime();
 
             element.id = elementId;

--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -301,11 +301,14 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 
         // if the user has specified an id on the node in which they're initializing on, use that ID as the name of the editor!
         if ( elementId ) {
-			// testing cache-busting
+
+            // update
+			// cache-busting
 			CKEDITOR.timestamp = new Date().getTime();
+
             element.id = elementId;
         }
-        
+
 		this.elementRef.nativeElement.appendChild( element );
 
 		const userInstanceReadyCallback = this.config?.on?.instanceReady;

--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -301,6 +301,8 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
 
         // if the user has specified an id on the node in which they're initializing on, use that ID as the name of the editor!
         if ( elementId ) {
+			// testing cache-busting
+			CKEDITOR.timestamp = new Date().getTime();
             element.id = elementId;
         }
         

--- a/src/ckeditor/ckeditor.component.ts
+++ b/src/ckeditor/ckeditor.component.ts
@@ -300,16 +300,14 @@ export class CKEditorComponent implements AfterViewInit, OnDestroy, ControlValue
         const elementId = this.elementRef.nativeElement.id;
 
         // if the user has specified an id on the node in which they're initializing on, use that ID as the name of the editor!
-        if ( elementId ) {
-
-            // update
-			// cache-busting
-            // test commit
-			CKEDITOR.timestamp = new Date().getTime();
-
+        if (elementId) {
+            // ysi
+            const version = (document.querySelector('#app-version') as HTMLInputElement)?.value;
+            console.log('set..');
+            console.log('Build Version: ', version);            
+            CKEDITOR.timestamp = version;
             element.id = elementId;
-        }
-
+        }        
 		this.elementRef.nativeElement.appendChild( element );
 
 		const userInstanceReadyCallback = this.config?.on?.instanceReady;


### PR DESCRIPTION
It is very important to our implementation that this behavior exists. This is how it function in vanilla ck4 and I see no harm in adding in the optional ability to support it. IF your target has an ID, use that as the editor.name rather than just assigning numeric values, such as editor1, editor2. 

Please consider adding this to MASTER, it would greatly be appreciated.